### PR TITLE
⚡ Bolt: Optimize model unloading to reduce lock contention

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-02-18 - Pre-scaled Audio Feedback
 **Learning:** AudioFeedback volume scaling was applied during every playback, causing unnecessary numpy overhead and latency.
 **Action:** Pre-calculate scaled audio during `_load_and_cache` to minimize `_play_cached` latency (from ~1ms to ~0.04ms).
+
+## 2024-02-18 - Lock Contention in Model Unloading
+**Learning:** `ParakeetManager._unload_model` executed `gc.collect()` inside the thread lock, potentially blocking transcription requests for hundreds of milliseconds during cleanup.
+**Action:** Move `gc.collect()` outside the critical section to allow concurrent lock acquisition by other threads.

--- a/src/chirp/parakeet_manager.py
+++ b/src/chirp/parakeet_manager.py
@@ -65,11 +65,16 @@ class ParakeetManager:
                 self._unload_model()
 
     def _unload_model(self) -> None:
+        should_collect = False
         with self._lock:
             if self._model is not None and (time.time() - self._last_access > self._timeout):
                 self._logger.info("Unloading Parakeet model to free memory.")
                 self._model = None
-                gc.collect()
+                should_collect = True
+
+        if should_collect:
+            # Run GC outside lock to prevent blocking other threads
+            gc.collect()
 
     def ensure_loaded(self):
         with self._lock:


### PR DESCRIPTION
### **User description**
💡 What: Moved `gc.collect()` outside the thread lock in `ParakeetManager._unload_model`.
🎯 Why: `gc.collect()` is a blocking operation. Running it inside the lock blocked the main thread from acquiring the lock (e.g., to load the model for transcription) if it coincided with unloading.
📊 Impact: Eliminates potential latency spikes (100ms+) during model unloading, improving responsiveness.
🔬 Measurement: Verified with `test_parakeet_manager.py` to ensure thread safety and correctness.

---
*PR created automatically by Jules for task [9332975665535252449](https://jules.google.com/task/9332975665535252449) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Move `gc.collect()` outside thread lock in `_unload_model`

- Prevent blocking transcription requests during garbage collection

- Reduce lock contention and potential latency spikes (100ms+)

- Document optimization learning in bolt.md


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_unload_model called"] --> B["Acquire lock"]
  B --> C["Set should_collect flag"]
  C --> D["Release lock"]
  D --> E["Run gc.collect outside lock"]
  E --> F["Other threads can acquire lock"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parakeet_manager.py</strong><dd><code>Move gc.collect outside lock for concurrency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/parakeet_manager.py

<ul><li>Moved <code>gc.collect()</code> call outside the thread lock in <code>_unload_model</code> <br>method<br> <li> Introduced <code>should_collect</code> flag to signal when garbage collection is <br>needed<br> <li> Lock is now released before executing the blocking <code>gc.collect()</code> <br>operation<br> <li> Added explanatory comment about preventing thread blocking</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/35/files#diff-1e1157722142317b937daebf4aa7c4a920cfe67e018f405d8e5dd853155978e0">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document lock contention optimization learning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Added new learning entry documenting the lock contention issue<br> <li> Recorded the optimization action taken to move <code>gc.collect()</code> outside <br>critical section<br> <li> Captured the problem context and solution approach</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/35/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

