### PR TITLE
🎨 Palette: Add visual status feedback to CLI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-01-27 - Visual Feedback for CLI Async Operations
+**Learning:** CLI applications often lack immediate visual feedback for long-running or modal operations (like recording audio or transcribing), leaving users unsure if the app is working.
+**Action:** Use `rich.console.Status` (spinners) to provide immediate, persistent visual feedback for active states ("Recording...", "Transcribing...") alongside standard logging. Ensure status indicators are managed (started/stopped) around the blocking or async operations.


### PR DESCRIPTION
### **User description**
This PR adds visual status feedback to the Chirp CLI application.

### 💡 What
- Added a "Recording..." status spinner (red dots) that appears when recording starts and disappears when it stops.
- Added a "Transcribing..." status spinner (yellow dots) that appears during the transcription process.

### 🎯 Why
- Users previously had to rely on log messages ("Recording started") which scroll up, or audio cues.
- Provides immediate confirmation that the application is listening or processing.
- Improves accessibility for users who may miss audio cues or are looking at the terminal.

### 📸 Visuals
The terminal now shows:
`⠋ Recording...` (Red spinner)
`⠋ Transcribing...` (Yellow spinner)

### ♿ Accessibility
- Uses `rich` which supports screen readers and non-interactive terminals gracefully.
- Provides text status alongside the spinner.

---
*PR created automatically by Jules for task [4827485420782214509](https://jules.google.com/task/4827485420782214509) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add visual status spinners for recording and transcribing operations

- Store console instance in ChirpApp for unified UI management

- Display "Recording..." with red spinner during audio capture

- Display "Transcribing..." with yellow spinner during transcription

- Document design decision in Palette's journal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp.__init__"] -- "stores console" --> B["self.console"]
  B -- "creates status" --> C["_status_indicator"]
  D["_start_recording"] -- "starts" --> C
  C -- "shows Recording..." --> E["User sees red spinner"]
  F["_stop_recording"] -- "stops" --> C
  G["_transcribe_and_inject"] -- "uses context manager" --> H["Transcribing... yellow spinner"]
  H --> I["User sees yellow spinner"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add visual status indicators for recording and transcription</code></dd></summary>
<hr>

src/chirp/main.py

<ul><li>Store console instance as <code>self.console</code> for reuse across methods<br> <li> Create <code>_status_indicator</code> with red "Recording..." spinner in <code>__init__</code><br> <li> Call <code>_status_indicator.start()</code> in <code>_start_recording()</code> method<br> <li> Call <code>_status_indicator.stop()</code> in <code>_stop_recording()</code> method<br> <li> Wrap transcription call with <code>console.status()</code> context manager for <br>yellow "Transcribing..." spinner</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/36/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document visual feedback design decision and rationale</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Create new Palette's journal file documenting design decision<br> <li> Record learning about lack of visual feedback in CLI async operations<br> <li> Document action taken using <code>rich.console.Status</code> spinners<br> <li> Explain importance of managing status indicator lifecycle</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/36/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

