### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix audio file memory exhaustion risk

### DIFF
--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -55,6 +55,7 @@ class TestAudioFeedback(unittest.TestCase):
         mock_wave.open.return_value.__enter__.return_value = mock_wf
         mock_wf.getframerate.return_value = 44100
         mock_wf.getnchannels.return_value = 1
+        mock_wf.getsampwidth.return_value = 2
         mock_wf.getnframes.return_value = 1000
         mock_wf.readframes.return_value = b"\x00" * 2000
 
@@ -99,6 +100,7 @@ class TestAudioFeedback(unittest.TestCase):
         mock_wave.open.return_value.__enter__.return_value = mock_wf
         mock_wf.getframerate.return_value = 44100
         mock_wf.getnchannels.return_value = 1
+        mock_wf.getsampwidth.return_value = 2
         mock_wf.readframes.return_value = b"\x00" * 2000  # Dummy bytes
         mock_wf.getnframes.return_value = 1000
 

--- a/tests/test_audio_feedback_security.py
+++ b/tests/test_audio_feedback_security.py
@@ -1,0 +1,58 @@
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from chirp.audio_feedback import AudioFeedback
+
+
+class TestAudioFeedbackSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+
+    @patch("chirp.audio_feedback.sd")
+    @patch("chirp.audio_feedback.np")
+    @patch("chirp.audio_feedback.wave")
+    @patch("chirp.audio_feedback.winsound", None)
+    def test_load_large_file_raises_error(self, mock_wave, mock_np, mock_sd):
+        """_load_and_cache should raise an error if the audio file is too large."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock wave reading to simulate a large file (e.g. > 10MB)
+        mock_wf = MagicMock()
+        mock_wave.open.return_value.__enter__.return_value = mock_wf
+        mock_wf.getframerate.return_value = 44100
+        mock_wf.getnchannels.return_value = 2
+        mock_wf.getsampwidth.return_value = 2
+        # 2 channels * 2 bytes = 4 bytes per frame.
+        # 3,000,000 frames * 4 bytes = 12 MB.
+        mock_wf.getnframes.return_value = 3_000_000
+
+        # We expect this to raise a ValueError or similar
+        with self.assertRaises(ValueError) as cm:
+            af._load_and_cache(Path("/fake/large_sound.wav"), "large_sound")
+
+        self.assertIn("too large", str(cm.exception))
+
+    @patch("chirp.audio_feedback.sd")
+    @patch("chirp.audio_feedback.np")
+    @patch("chirp.audio_feedback.wave")
+    @patch("chirp.audio_feedback.winsound", None)
+    def test_load_small_file_succeeds(self, mock_wave, mock_np, mock_sd):
+        """_load_and_cache should succeed for small files."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock wave reading to simulate a small file
+        mock_wf = MagicMock()
+        mock_wave.open.return_value.__enter__.return_value = mock_wf
+        mock_wf.getframerate.return_value = 44100
+        mock_wf.getnchannels.return_value = 1
+        mock_wf.getsampwidth.return_value = 2
+        # 1000 frames * 2 bytes = 2000 bytes.
+        mock_wf.getnframes.return_value = 1000
+        mock_wf.readframes.return_value = b"\x00" * 2000
+
+        mock_np.frombuffer.return_value = MagicMock()
+
+        af._load_and_cache(Path("/fake/small_sound.wav"), "small_sound")
+        # Should not raise


### PR DESCRIPTION
### **User description**
Enforces a 5MB limit on audio files loaded by `AudioFeedback` to prevent memory exhaustion (DoS).
This addresses a medium-severity security risk where a large audio file could be loaded into memory, causing the application to crash or consume excessive resources.
Includes a new security test file and updates existing tests to mock the file size check correctly.

---
*PR created automatically by Jules for task [3130907553259107130](https://jules.google.com/task/3130907553259107130) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforces 5MB limit on audio files to prevent memory exhaustion DoS attacks

- Validates file size before loading into memory in `AudioFeedback._load_and_cache()`

- Adds comprehensive security test suite for large file rejection

- Updates existing tests to mock `getsampwidth()` for accurate size calculation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Loading"] --> B["Calculate Total Bytes"]
  B --> C["Compare to 5MB Limit"]
  C --> D["Size OK"]
  C --> E["Size Exceeded"]
  D --> F["Load into Memory"]
  E --> G["Raise ValueError"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add 5MB audio file size validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Adds <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implements security check in <code>_load_and_cache()</code> to calculate total <br>audio file size<br> <li> Raises <code>ValueError</code> if file exceeds 5MB limit before loading into memory<br> <li> Prevents DoS attacks via memory exhaustion from malicious audio files</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/37/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Update mocks to support size validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Adds <code>mock_wf.getsampwidth.return_value = 2</code> to existing test mocks<br> <li> Updates <code>test_load_and_cache_sounddevice()</code> to mock sample width<br> <li> Updates <code>test_load_and_cache_with_volume_scaling()</code> to mock sample width<br> <li> Ensures tests accurately reflect new size calculation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/37/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback_security.py</strong><dd><code>Add audio file security test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback_security.py

<ul><li>New security test file with two test cases<br> <li> <code>test_load_large_file_raises_error()</code> verifies 12MB file rejection<br> <li> <code>test_load_small_file_succeeds()</code> verifies 2KB file acceptance<br> <li> Comprehensive coverage of size limit enforcement</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/37/files#diff-dfeb4162cb68486be46f848227b78c4f401833ebe2129673faf2342d154e40d5">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

