### PR TITLE
🎨 Palette: Add transcription status spinner

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-28 - CLI Async Feedback
+**Learning:** In CLI apps using `rich`, heavy operations (like inference) running in background threads leave the user guessing if the app is frozen.
+**Action:** Use `console.status` context managers inside worker threads to provide "alive" feedback (spinners) without blocking the main UI loop.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -60,9 +60,10 @@ class ChirpApp:
                 break
         if not console:
             console = Console(stderr=True)
+        self.console = console
 
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -153,7 +154,8 @@ class ChirpApp:
             self.logger.warning("No audio samples captured")
             return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            with self.console.status("[bold yellow]Transcribing...[/bold yellow]", spinner="dots"):
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
         except Exception as exc:
             self.logger.exception("Transcription failed: %s", exc)
             self.audio_feedback.play_error(self.config.error_sound_path)


### PR DESCRIPTION
### **User description**
💡 **What:** Added a "Transcribing..." loading spinner using `rich`'s `Console.status` during the speech-to-text inference phase.
🎯 **Why:** Parakeet STT on CPU can take a few seconds to process audio. Users previously saw no visual feedback between stopping recording and the text appearing, leading to uncertainty about whether the app was working.
📸 **Before/After:**
*(Before)* Log output jumps from "Recording stopped" ... [pause] ... "Transcription finished"
*(After)* Log output shows "Recording stopped", then a yellow spinner "Transcribing..." appears until the text is ready.
♿ **Accessibility:** Provides visual confirmation of background processing state without blocking the UI thread.

---
*PR created automatically by Jules for task [9862779291806208874](https://jules.google.com/task/9862779291806208874) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add visual spinner feedback during transcription processing

- Store console instance in ChirpApp for reuse across methods

- Document UX learning about CLI async feedback patterns

- Improve user experience by showing "Transcribing..." status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp.__init__"] -->|store console| B["self.console"]
  B -->|reuse in| C["_transcribe_and_inject"]
  C -->|wrap with| D["console.status spinner"]
  D -->|display| E["Transcribing... feedback"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add transcription spinner and store console instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Store <code>console</code> instance as <code>self.console</code> in <code>ChirpApp.__init__</code> for reuse<br> <li> Update initialization spinner to use <code>self.console</code> instead of local <br>variable<br> <li> Wrap <code>parakeet.transcribe()</code> call with <code>console.status()</code> context manager<br> <li> Display yellow "Transcribing..." spinner during speech-to-text <br>inference</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/39/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document CLI async feedback learning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Document UX learning about CLI async feedback patterns<br> <li> Explain issue of heavy operations in background threads without visual <br>feedback<br> <li> Record solution of using <code>console.status</code> context managers for spinner <br>feedback</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/39/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

