### PR TITLE
🎨 Palette: Add visual status for transcription

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2024-05-23 - Visual Feedback for Long-Running Operations
+**Learning:** Users lack confidence when the application performs long-running background tasks (like transcription on CPU) without visual feedback in the CLI. The existing logging is helpful for debugging but insufficient for "alive" status.
+**Action:** Implement `rich.console.Status` spinners for all blocking or long-running operations (Transcription, Initialization) to provide immediate, reassuring feedback.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -60,9 +60,10 @@ class ChirpApp:
                 break
         if not console:
             console = Console(stderr=True)
+        self.console = console
 
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -153,7 +154,8 @@ class ChirpApp:
             self.logger.warning("No audio samples captured")
             return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            with self.console.status("[bold yellow]Transcribing...[/bold yellow]", spinner="dots"):
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
         except Exception as exc:
             self.logger.exception("Transcription failed: %s", exc)
             self.audio_feedback.play_error(self.config.error_sound_path)

--- a/tests/test_chirp_app.py
+++ b/tests/test_chirp_app.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+from pathlib import Path
+
+# Mock dependencies that require C libs or hardware access
+mock_sd = MagicMock()
+sys.modules["sounddevice"] = mock_sd
+mock_keyboard = MagicMock()
+sys.modules["keyboard"] = mock_keyboard
+mock_winsound = MagicMock()
+sys.modules["winsound"] = mock_winsound
+mock_pyperclip = MagicMock()
+sys.modules["pyperclip"] = mock_pyperclip
+
+# Ensure src is in path
+sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
+
+import numpy as np  # noqa: E402
+from chirp.main import ChirpApp  # noqa: E402
+
+class TestChirpAppStatus(unittest.TestCase):
+    @patch('chirp.main.TextInjector')
+    @patch('chirp.main.KeyboardShortcutManager')
+    @patch('chirp.main.AudioFeedback')
+    @patch('chirp.main.AudioCapture')
+    @patch('chirp.main.ParakeetManager')
+    @patch('chirp.main.ConfigManager')
+    @patch('chirp.main.RichHandler')
+    @patch('chirp.main.get_logger')
+    def test_transcription_shows_status(
+        self,
+        mock_get_logger,
+        mock_rich_handler_cls,
+        mock_config_manager,
+        mock_parakeet_cls,
+        mock_audio_capture,
+        mock_audio_feedback,
+        mock_keyboard,
+        mock_text_injector
+    ):
+        with patch('chirp.main.Console') as MockConsole:
+            # Force fallback to new Console creation
+            mock_logger = MagicMock()
+            mock_logger.handlers = []
+            mock_get_logger.return_value = mock_logger
+
+            app = ChirpApp()
+
+            mock_console_instance = MockConsole.return_value
+
+            # Reset mocks
+            mock_console_instance.reset_mock()
+
+            # Run transcribe
+            waveform = np.zeros(1024, dtype=np.float32)
+            app.parakeet.transcribe.return_value = "Test text"
+
+            app._transcribe_and_inject(waveform)
+
+            # Verify status was called with Transcribing...
+            mock_console_instance.status.assert_called_with("[bold yellow]Transcribing...[/bold yellow]", spinner="dots")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
💡 **What**: Added a `rich` console spinner during the transcription phase.
🎯 **Why**: Users had no visual feedback while the model was processing audio (especially on CPU), leading to uncertainty if the app was working.
📸 **Visuals**: Now displays a "[bold yellow]Transcribing...[/bold yellow]" spinner during inference.
♿ **Accessibility**: Improved system status visibility for CLI users.

---
*PR created automatically by Jules for task [15794722885574100269](https://jules.google.com/task/15794722885574100269) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add visual status spinner during transcription phase

- Store console instance as class attribute for reuse

- Add unit tests for transcription status display

- Document UX improvements in palette journal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp initialization"] -- "stores console instance" --> B["self.console"]
  B -- "used in __init__" --> C["Model initialization spinner"]
  B -- "used in _transcribe_and_inject" --> D["Transcription spinner"]
  E["Unit tests"] -- "verify status calls" --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add transcription spinner and store console</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Store console instance as <code>self.console</code> attribute for reuse across <br>methods<br> <li> Wrap <code>parakeet.transcribe()</code> call with <code>self.console.status()</code> spinner <br>showing "[bold yellow]Transcribing...[/bold yellow]"<br> <li> Update initialization spinner to use stored console instance</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/41/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chirp_app.py</strong><dd><code>Add unit tests for transcription status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_chirp_app.py

<ul><li>Create new test file with comprehensive mocking of external <br>dependencies<br> <li> Add <code>TestChirpAppStatus</code> class with <code>test_transcription_shows_status</code> test <br>method<br> <li> Verify that <code>console.status()</code> is called with correct transcription <br>message and spinner type<br> <li> Mock all hardware/C library dependencies (sounddevice, keyboard, <br>winsound, pyperclip)</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/41/files#diff-ad5159e05abc3bdff12e5be14310a13e1a268f46c3567f8d1e56256fb9c4523d">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document UX improvements and learnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Document UX learning about lack of visual feedback during long-running <br>operations<br> <li> Record decision to implement <code>rich.console.Status</code> spinners for blocking <br>operations<br> <li> Note specific use cases: transcription and model initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/41/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

