### PR TITLE
⚡ Bolt: Preload audio assets to eliminate first-use latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-02-18 - Pre-scaled Audio Feedback
 **Learning:** AudioFeedback volume scaling was applied during every playback, causing unnecessary numpy overhead and latency.
 **Action:** Pre-calculate scaled audio during `_load_and_cache` to minimize `_play_cached` latency (from ~1ms to ~0.04ms).
+
+## 2026-01-29 - Audio Feedback Preloading
+**Learning:** Initial audio feedback (e.g. "ping-up.wav") suffered from file I/O latency on the first activation, making the app feel sluggish.
+**Action:** Implemented `preload_start/stop/error` in `AudioFeedback` and called them during `ChirpApp` initialization to cache sounds before user interaction.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -52,6 +52,9 @@ class ChirpApp:
             enabled=self.config.audio_feedback,
             volume=self.config.audio_feedback_volume,
         )
+        self.audio_feedback.preload_start(self.config.start_sound_path)
+        self.audio_feedback.preload_stop(self.config.stop_sound_path)
+        self.audio_feedback.preload_error(self.config.error_sound_path)
 
         console = None
         for handler in self.logger.handlers:


### PR DESCRIPTION
### **User description**
💡 What: Implemented `preload_start`, `preload_stop`, and `preload_error` in `AudioFeedback` and invoked them during `ChirpApp` initialization.
🎯 Why: To eliminate the latency caused by file I/O and resource extraction on the first use of the "start recording" hotkey.
📊 Impact: Instant audio feedback on the first toggle, improving perceived responsiveness.
🔬 Measurement: Verified via unit tests that `_cache` is populated upon calling preload methods.

---
*PR created automatically by Jules for task [13119295005356835414](https://jules.google.com/task/13119295005356835414) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Preload audio assets during app initialization to eliminate first-use latency

- Added `preload_start`, `preload_stop`, `preload_error` methods to `AudioFeedback`

- Integrated preloading into `ChirpApp` startup sequence

- Added unit tests verifying cache population on preload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp Initialization"] -->|calls| B["preload_start"]
  A -->|calls| C["preload_stop"]
  A -->|calls| D["preload_error"]
  B -->|caches| E["AudioFeedback._cache"]
  C -->|caches| E
  D -->|caches| E
  E -->|instant playback| F["User Interaction"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add audio preloading methods to AudioFeedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added three preload methods: <code>preload_start()</code>, <code>preload_stop()</code>, <br><code>preload_error()</code> to cache audio files<br> <li> Implemented <code>_preload()</code> helper method that loads and caches sound files <br>with error handling<br> <li> <code>preload_error()</code> includes special logic to only preload when custom <br>path is provided<br> <li> All preload methods skip execution if audio feedback is disabled</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/42/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Invoke audio preloading during app startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Integrated preload calls into <code>ChirpApp.__init__()</code> after <code>AudioFeedback</code> <br>initialization<br> <li> Calls <code>preload_start()</code>, <code>preload_stop()</code>, <code>preload_error()</code> with configured <br>sound paths<br> <li> Ensures audio assets are cached before any user interaction occurs</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/42/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Add unit tests for audio preloading functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Added <code>test_preload_start_populates_cache()</code> to verify cache population <br>on preload<br> <li> Added <code>test_preload_error_requires_override()</code> to verify override path <br>requirement<br> <li> Tests mock <code>_load_and_cache</code> and <code>_get_sound_path</code> to isolate preload <br>logic<br> <li> Validates that preload methods correctly interact with internal <br>caching mechanism</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/42/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document audio preloading optimization learning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Added learning entry documenting the audio feedback preloading <br>optimization<br> <li> Records the problem (file I/O latency on first activation) and <br>solution (preload during initialization)<br> <li> Maintains historical context for future performance improvements</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/42/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

