### PR TITLE
🛡️ Sentinel: [medium] Enforce 5MB limit on audio feedback files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Control characters could be injected via `word_overrides` configuration, bypassing initial input sanitization.
 **Learning:** Initial input sanitization is insufficient when configuration data (overrides) can re-introduce unsafe characters during processing.
 **Prevention:** Implement "Output Sanitization" as a final step in data processing pipelines. Ensure sanitization logic is reusable and safe (e.g., does not unintentionally destroy formatting like trailing whitespace unless intended).
+
+## 2026-01-29 - Unbounded Resource Loading (DoS)
+**Vulnerability:** `AudioFeedback` loaded audio files into memory without size checks, allowing a potential Denial of Service (OOM) via large files.
+**Learning:** Libraries like `sounddevice` or `wave` often process files in-memory. Assuming assets are small/safe is risky when paths are configurable by users.
+**Prevention:** Enforce strict size limits (e.g. 5MB) on all user-configurable file loads before opening/reading them.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -5,7 +5,7 @@ import platform
 import wave
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, Optional
 
 from importlib import resources
 
@@ -23,6 +23,9 @@ try:
     import winsound  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
+
+
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
 class AudioFeedback:
@@ -130,6 +133,9 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        if path.stat().st_size > MAX_AUDIO_FILE_SIZE_BYTES:
+            raise ValueError(f"Audio file too large: {path} (max 5MB)")
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -62,7 +62,10 @@ class TestAudioFeedback(unittest.TestCase):
         mock_np.frombuffer.return_value = mock_audio_data
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+        mock_path = MagicMock(spec=Path)
+        mock_path.__str__.return_value = "/fake/sound.wav"
+        mock_path.stat.return_value.st_size = 100  # Valid size
+        data = af._load_and_cache(mock_path, key)
 
         mock_wave.open.assert_called_with("/fake/sound.wav", "rb")
         mock_np.frombuffer.assert_called()
@@ -110,7 +113,10 @@ class TestAudioFeedback(unittest.TestCase):
         af = AudioFeedback(logger=self.mock_logger, enabled=True, volume=0.5)
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+        mock_path = MagicMock(spec=Path)
+        mock_path.__str__.return_value = "/fake/sound.wav"
+        mock_path.stat.return_value.st_size = 100  # Valid size
+        data = af._load_and_cache(mock_path, key)
 
         audio_data, samplerate = data
 

--- a/tests/test_audio_feedback_cache.py
+++ b/tests/test_audio_feedback_cache.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from pathlib import Path
 import logging
 
 from chirp.audio_feedback import AudioFeedback

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+from chirp.audio_feedback import AudioFeedback
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock()
+
+    @patch("chirp.audio_feedback.sd", new=MagicMock())  # Ensure enabled=True works
+    def test_audio_file_too_large(self):
+        """AudioFeedback should raise ValueError for files > 5MB."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock path and stat
+        mock_path = MagicMock(spec=Path)
+        # 5MB + 1 byte
+        mock_path.stat.return_value.st_size = 5 * 1024 * 1024 + 1
+
+        with self.assertRaises(ValueError) as cm:
+            af._load_and_cache(mock_path, "key")
+
+        self.assertIn("Audio file too large", str(cm.exception))
+
+    @patch("chirp.audio_feedback.sd", new=MagicMock())
+    @patch("chirp.audio_feedback.wave")
+    @patch("chirp.audio_feedback.np")
+    def test_audio_file_size_ok(self, mock_np, mock_wave):
+        """AudioFeedback should accept files <= 5MB."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock path and stat
+        mock_path = MagicMock(spec=Path)
+        mock_path.stat.return_value.st_size = 5 * 1024 * 1024 # Exactly 5MB
+        mock_path.__str__.return_value = "/fake/file.wav"
+
+        # Mock wave reading internals to avoid errors
+        mock_wf = MagicMock()
+        mock_wave.open.return_value.__enter__.return_value = mock_wf
+        mock_wf.getnchannels.return_value = 1
+        mock_wf.readframes.return_value = b""
+        mock_np.frombuffer.return_value = MagicMock() # Mock array
+
+        try:
+            af._load_and_cache(mock_path, "key")
+        except ValueError:
+            self.fail("AudioFeedback raised ValueError for valid file size")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
This PR addresses a potential Denial of Service (DoS) vulnerability in the `AudioFeedback` class. Previously, the application would attempt to load any audio file specified in the configuration, regardless of size, into memory. This could lead to memory exhaustion if a user (or attacker with config access) specified a very large file.

Changes:
- Added `MAX_AUDIO_FILE_SIZE_BYTES` constant (5MB) in `src/chirp/audio_feedback.py`.
- Implemented a check in `_load_and_cache` to verify `path.stat().st_size` before opening the file.
- Raises `ValueError` if the file exceeds the limit.
- Updated `tests/test_audio_feedback.py` to mock `path.stat().st_size` for existing tests.
- Added new test suite `tests/test_audio_security.py` to verify the security constraint.
- Updated `.jules/sentinel.md` with the new learning.

---
*PR created automatically by Jules for task [3966165985324086936](https://jules.google.com/task/3966165985324086936) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added 5MB file size limit to prevent DoS via memory exhaustion

- Implemented validation check in `_load_and_cache` method

- Updated existing tests to mock file size properly

- Added comprehensive security test suite for file size enforcement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Load Request"] --> B["Check File Size"]
  B --> C{Size <= 5MB?}
  C -->|Yes| D["Load and Cache"]
  C -->|No| E["Raise ValueError"]
  D --> F["Return Audio Data"]
  E --> G["Prevent Memory Exhaustion"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add file size validation for audio files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implemented file size validation in <code>_load_and_cache</code> method before file <br>opening<br> <li> Raises <code>ValueError</code> if file exceeds 5MB limit<br> <li> Removed unused type imports (<code>Tuple</code>, <code>Union</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/43/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Mock file size in existing audio tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Updated <code>test_load_and_cache_sounddevice</code> to mock <code>Path</code> object with <br><code>stat().st_size</code><br> <li> Updated <code>test_load_and_cache_with_volume_scaling</code> to mock <code>Path</code> object <br>with valid file size<br> <li> Ensures existing tests work with new size validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/43/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>Add audio file size security tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>New test file for audio security constraints<br> <li> <code>test_audio_file_too_large</code>: Verifies <code>ValueError</code> raised for files <br>exceeding 5MB<br> <li> <code>test_audio_file_size_ok</code>: Verifies files at exactly 5MB are accepted<br> <li> Comprehensive mocking of <code>wave</code> and <code>numpy</code> modules</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/43/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback_cache.py</strong><dd><code>Remove unused import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback_cache.py

- Removed unused `Path` import from test file


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/43/files#diff-5d94a71896d6e8d308f089ffae29fc293d3d18f9e25eb0864acb238813aa5ada">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentinel.md</strong><dd><code>Document audio DoS vulnerability and prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/sentinel.md

<ul><li>Added new security learning entry documenting unbounded resource <br>loading vulnerability<br> <li> Documented the DoS risk from in-memory audio file processing<br> <li> Recorded prevention strategy of enforcing strict size limits on <br>configurable file loads</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/43/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

