### PR TITLE
🛡️ Sentinel: Enforce file size limit on audio assets

### DIFF
--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -25,6 +25,9 @@ except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
 
 
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
+
+
 class AudioFeedback:
     def __init__(
         self,
@@ -130,6 +133,11 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        if path.stat().st_size > MAX_AUDIO_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"File size exceeds limit of {MAX_AUDIO_FILE_SIZE_BYTES} bytes: {path}"
+            )
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -46,8 +46,10 @@ class TestAudioFeedback(unittest.TestCase):
     @patch("chirp.audio_feedback.sd")
     @patch("chirp.audio_feedback.np")
     @patch("chirp.audio_feedback.wave")
-    def test_load_and_cache_sounddevice(self, mock_wave, mock_np, mock_sd):
+    @patch("pathlib.Path.stat")
+    def test_load_and_cache_sounddevice(self, mock_stat, mock_wave, mock_np, mock_sd):
         """_load_and_cache should read WAV and cache data."""
+        mock_stat.return_value.st_size = 100
         af = AudioFeedback(logger=self.mock_logger, enabled=True)
 
         # Setup wave mock
@@ -85,8 +87,10 @@ class TestAudioFeedback(unittest.TestCase):
     @patch("chirp.audio_feedback.np")
     @patch("chirp.audio_feedback.wave")
     @patch("chirp.audio_feedback.winsound", None)
-    def test_load_and_cache_with_volume_scaling(self, mock_wave, mock_np, mock_sd):
+    @patch("pathlib.Path.stat")
+    def test_load_and_cache_with_volume_scaling(self, mock_stat, mock_wave, mock_np, mock_sd):
         """_load_and_cache should scale audio when volume < 1.0."""
+        mock_stat.return_value.st_size = 100
         import numpy as np
 
         # Create real numpy array for testing

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import logging
+from pathlib import Path
+
+from chirp.audio_feedback import AudioFeedback, MAX_AUDIO_FILE_SIZE_BYTES
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger("TestLogger")
+        self.logger.setLevel(logging.CRITICAL)
+
+        # Instantiate AudioFeedback
+        self.audio_feedback = AudioFeedback(
+            logger=self.logger,
+            enabled=True,
+            volume=0.5
+        )
+
+    @patch("pathlib.Path.stat")
+    def test_large_file_rejection(self, mock_stat):
+        """Test that files larger than the limit are rejected."""
+        # Limit + 1 byte
+        large_size = MAX_AUDIO_FILE_SIZE_BYTES + 1
+        mock_stat.return_value.st_size = large_size
+
+        test_path = Path("fake_large_file.wav")
+
+        # Expect ValueError because of size limit
+        with self.assertRaises(ValueError) as cm:
+            self.audio_feedback._load_and_cache(test_path, "test_key")
+
+        self.assertIn("File size exceeds limit", str(cm.exception))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
🛡️ Sentinel: [MEDIUM] Prevent Memory Exhaustion via Large Audio Files

**Vulnerability:**
The `AudioFeedback` class previously loaded audio files of arbitrary size into memory using `wave.readframes` (or via `winsound` caching), which could lead to memory exhaustion and application crash (Denial of Service) if a user configured a very large file in `config.toml`.

**Fix:**
- Enforced a 5MB limit (`MAX_AUDIO_FILE_SIZE_BYTES`) on any audio file loaded by `AudioFeedback`.
- The check is performed using `path.stat().st_size` before opening the file, preventing resource consumption.

**Verification:**
- Added `tests/test_audio_security.py` which verifies that loading a mock 5MB+1 byte file raises a `ValueError`.
- Verified that all existing tests pass with the new mock requirements.

---
*PR created automatically by Jules for task [12851286560280619058](https://jules.google.com/task/12851286560280619058) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce 5MB file size limit on audio files to prevent memory exhaustion

- Check file size before loading using `path.stat().st_size` in `_load_and_cache`

- Added security test verifying rejection of oversized audio files

- Updated existing tests to mock `pathlib.Path.stat` for compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Loading"] -->|Check Size| B["Size Check via stat()"]
  B -->|Under 5MB| C["Load and Cache"]
  B -->|Over 5MB| D["Raise ValueError"]
  C --> E["Play Audio"]
  D --> F["Prevent Memory Exhaustion"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add 5MB file size limit enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implemented file size validation in <code>_load_and_cache</code> method before file <br>loading<br> <li> Raises <code>ValueError</code> if file exceeds the 5MB limit</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/44/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Mock Path.stat for existing audio tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Added <code>@patch("pathlib.Path.stat")</code> decorator to two test methods<br> <li> Set mock <code>st_size</code> to 100 bytes in <code>test_load_and_cache_sounddevice</code><br> <li> Set mock <code>st_size</code> to 100 bytes in <br><code>test_load_and_cache_with_volume_scaling</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/44/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>Add audio file size security tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>New test file verifying security enforcement of audio file size limits<br> <li> Test <code>test_large_file_rejection</code> validates that files exceeding 5MB+1 <br>byte raise <code>ValueError</code><br> <li> Uses mocked <code>pathlib.Path.stat</code> to simulate oversized file scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/44/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

