### PR TITLE
⚡ Bolt: Move gc.collect() outside lock in ParakeetManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-02-18 - Pre-scaled Audio Feedback
 **Learning:** AudioFeedback volume scaling was applied during every playback, causing unnecessary numpy overhead and latency.
 **Action:** Pre-calculate scaled audio during `_load_and_cache` to minimize `_play_cached` latency (from ~1ms to ~0.04ms).
+
+## 2026-01-30 - Lock Contention with GC
+**Learning:** `gc.collect()` inside a thread lock blocks all other threads needing that lock, causing potential latency spikes during model unloading.
+**Action:** Move `gc.collect()` outside critical sections (locks) whenever possible, using flags to signal the need for collection.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -5,7 +5,7 @@ import platform
 import wave
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, Optional
 
 from importlib import resources
 

--- a/src/chirp/parakeet_manager.py
+++ b/src/chirp/parakeet_manager.py
@@ -65,11 +65,15 @@ class ParakeetManager:
                 self._unload_model()
 
     def _unload_model(self) -> None:
+        should_gc = False
         with self._lock:
             if self._model is not None and (time.time() - self._last_access > self._timeout):
                 self._logger.info("Unloading Parakeet model to free memory.")
                 self._model = None
-                gc.collect()
+                should_gc = True
+
+        if should_gc:
+            gc.collect()
 
     def ensure_loaded(self):
         with self._lock:

--- a/tests/test_audio_feedback_cache.py
+++ b/tests/test_audio_feedback_cache.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from pathlib import Path
 import logging
 
 from chirp.audio_feedback import AudioFeedback

--- a/tests/test_gc_optimization.py
+++ b/tests/test_gc_optimization.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import time
+import threading
+from pathlib import Path
+
+# Mocking modules before import if necessary, but unittest.mock.patch handles it better usually.
+# However, for type checking imports inside the file, we might need to be careful.
+
+from chirp.parakeet_manager import ParakeetManager
+
+class TestGCOptimization(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock()
+        self.mock_model_dir = MagicMock(spec=Path)
+        self.mock_model_dir.mkdir.return_value = None
+
+    @patch("chirp.parakeet_manager.gc")
+    @patch("chirp.parakeet_manager.onnx_asr")
+    @patch("chirp.parakeet_manager.ort")
+    def test_unload_model_gc_outside_lock(self, mock_ort, mock_onnx_asr, mock_gc):
+        """
+        Verifies that gc.collect() is called and that it is called
+        when the lock is NOT held.
+        """
+        # Setup
+        mock_model = MagicMock()
+        mock_onnx_asr.load_model.return_value = mock_model
+
+        manager = ParakeetManager(
+            model_name="test_model",
+            quantization=None,
+            provider_key="cpu",
+            threads=1,
+            logger=self.mock_logger,
+            model_dir=self.mock_model_dir,
+            timeout=1.0
+        )
+
+        # Ensure loaded
+        manager.ensure_loaded()
+        self.assertIsNotNone(manager._model)
+
+        # Simulate timeout
+        manager._last_access = time.time() - 2.0
+
+        # Replace the lock with a real lock that we can inspect
+        lock = threading.Lock()
+        manager._lock = lock
+
+        # Define a side effect for gc.collect that checks if lock is locked
+        def gc_side_effect():
+            if lock.locked():
+                raise RuntimeError("gc.collect() called while lock is held!")
+
+        mock_gc.collect.side_effect = gc_side_effect
+
+        # Attempt to unload
+        # In the unoptimized code, this should raise RuntimeError.
+        # In the optimized code, it should succeed.
+
+        try:
+            manager._unload_model()
+        except RuntimeError as e:
+            if "gc.collect() called while lock is held!" in str(e):
+                self.fail("Performance Regression: gc.collect() is being called inside the lock!")
+            raise e
+
+        # Verify gc was called
+        mock_gc.collect.assert_called_once()
+        self.assertIsNone(manager._model)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
⚡ Bolt: Move gc.collect() outside lock in ParakeetManager

💡 What:
Moved `gc.collect()` call outside the critical section (thread lock) in `ParakeetManager._unload_model`.

🎯 Why:
The `_unload_model` method is called by a background monitor thread. Previously, it held the lock while running `gc.collect()`, which can be a slow, blocking operation. If a user attempted to start recording or transcribe audio during this time, the `transcribe` method (which requires the same lock to update `_last_access`) would be blocked, causing latency.

📊 Impact:
Reduces lock contention on the main critical section of the inference manager. While `gc.collect()` is still a stop-the-world event in Python, releasing the lock ensures that threads waiting on this specific resource lock are not artificially delayed by the lock itself, allowing for better thread scheduling and responsiveness.

🔬 Measurement:
Added a new test `tests/test_gc_optimization.py` that mocks `gc.collect` and the lock to assert that garbage collection is triggered *only* when the lock is not held.


---
*PR created automatically by Jules for task [5584615449898733617](https://jules.google.com/task/5584615449898733617) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Move `gc.collect()` outside lock in `ParakeetManager._unload_model`

- Reduces lock contention and prevents transcription latency spikes

- Add test to verify garbage collection happens outside lock

- Clean up unused imports in related files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_unload_model called"] --> B["Set should_gc flag inside lock"]
  B --> C["Release lock"]
  C --> D["Call gc.collect outside lock"]
  D --> E["Prevent lock contention"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parakeet_manager.py</strong><dd><code>Move gc.collect outside lock critical section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/parakeet_manager.py

<ul><li>Refactored <code>_unload_model</code> to set <code>should_gc</code> flag inside lock<br> <li> Moved <code>gc.collect()</code> call outside critical section<br> <li> Prevents blocking other threads waiting for the lock</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/45/files#diff-1e1157722142317b937daebf4aa7c4a920cfe67e018f405d8e5dd853155978e0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gc_optimization.py</strong><dd><code>Add test for gc optimization behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_gc_optimization.py

<ul><li>New test file verifying gc.collect is called outside lock<br> <li> Uses mock lock to detect if gc.collect runs while lock held<br> <li> Ensures no performance regression in future changes</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/45/files#diff-3d9b2ac9fadf7eee24e13d4edefd1af19306c906ea7e23ed75bcf7852965952b">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Remove unused type imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

- Removed unused imports `Tuple` and `Union` from typing


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/45/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback_cache.py</strong><dd><code>Remove unused Path import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback_cache.py

- Removed unused `Path` import


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/45/files#diff-5d94a71896d6e8d308f089ffae29fc293d3d18f9e25eb0864acb238813aa5ada">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document gc lock contention optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Added learning note about lock contention with gc.collect<br> <li> Documented optimization action and rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/45/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

