### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unrestricted Audio File Loading (DoS)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Control characters could be injected via `word_overrides` configuration, bypassing initial input sanitization.
 **Learning:** Initial input sanitization is insufficient when configuration data (overrides) can re-introduce unsafe characters during processing.
 **Prevention:** Implement "Output Sanitization" as a final step in data processing pipelines. Ensure sanitization logic is reusable and safe (e.g., does not unintentionally destroy formatting like trailing whitespace unless intended).
+
+## 2025-05-21 - Unrestricted Audio File Loading (DoS)
+**Vulnerability:** `AudioFeedback` loaded entire audio files into memory without size checks, allowing a potential Memory Exhaustion DoS via large configured file paths.
+**Learning:** Implicit trust in local configuration files can still lead to resource exhaustion if user input (file paths) points to massive resources.
+**Prevention:** Enforce strict resource limits (e.g., file size caps) on all loaded assets, even those specified in local configuration.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -25,6 +25,9 @@ except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
 
 
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
 class AudioFeedback:
     def __init__(
         self,
@@ -130,6 +133,13 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        # Security check: prevent loading massive files (DoS)
+        file_size = path.stat().st_size
+        if file_size > MAX_AUDIO_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"Audio file '{path.name}' too large ({file_size} > {MAX_AUDIO_FILE_SIZE_BYTES} bytes)"
+            )
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -62,7 +62,9 @@ class TestAudioFeedback(unittest.TestCase):
         mock_np.frombuffer.return_value = mock_audio_data
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
         mock_wave.open.assert_called_with("/fake/sound.wav", "rb")
         mock_np.frombuffer.assert_called()
@@ -110,7 +112,9 @@ class TestAudioFeedback(unittest.TestCase):
         af = AudioFeedback(logger=self.mock_logger, enabled=True, volume=0.5)
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
         audio_data, samplerate = data
 

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,39 @@
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from chirp.audio_feedback import AudioFeedback
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+
+    @patch("chirp.audio_feedback.sd", new=MagicMock())
+    @patch("chirp.audio_feedback.winsound", None)
+    def test_load_and_cache_rejects_large_files(self):
+        """_load_and_cache should raise ValueError if file exceeds size limit."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock Path.stat to return a large size
+        large_size = 6 * 1024 * 1024  # 6MB
+
+        # We patch Path.stat so that any Path object's stat() method returns our mock
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = large_size
+
+            # We don't need to mock wave.open because it should fail BEFORE opening the file
+            # If it tries to open, it means the security check failed (or doesn't exist)
+            # and potentially would raise FileNotFoundError since the file doesn't exist,
+            # but we want to assert it raises ValueError specifically due to size.
+
+            # To distinguish from FileNotFoundError (if it proceeds to open),
+            # we rely on the specific ValueError expectation.
+
+            with self.assertRaises(ValueError) as cm:
+                af._load_and_cache(Path("fake_large_file.wav"), "key")
+
+            self.assertIn("too large", str(cm.exception))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
# 🛡️ Sentinel: [MEDIUM] Fix Unrestricted Audio File Loading (DoS)

## 🚨 Severity: MEDIUM

## 💡 Vulnerability
The `AudioFeedback` class (used for start/stop sounds) loaded audio files into memory using `wave.readframes` without checking the file size. If a user configuration pointed `start_sound_path` or `stop_sound_path` to a very large file (e.g., gigabytes), this would cause the application to consume excessive memory and crash (Denial of Service).

## 🎯 Impact
A malicious or accidental configuration could crash the application or the host system by exhausting available RAM.

## 🔧 Fix
- Added a constant `MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024` (5MB).
- Updated `AudioFeedback._load_and_cache` to check `path.stat().st_size` before opening the file.
- Raises a `ValueError` if the file exceeds the limit, which is caught and logged as a warning, preventing the crash.

## ✅ Verification
1.  **New Security Test:** `tests/test_audio_security.py` confirms that attempting to load a mocked 6MB file raises `ValueError`.
2.  **Regression Testing:** `tests/test_audio_feedback.py` confirms that standard functionality (loading small files) works as expected (tests updated to mock valid file sizes).
3.  **Manual Check:** Verified that `_load_and_cache` logic prevents `wave.open` from being called on oversized files.

---
*PR created automatically by Jules for task [12584136905054009415](https://jules.google.com/task/12584136905054009415) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added 5MB file size limit to prevent memory exhaustion DoS attacks

- Validates audio file sizes before loading in `AudioFeedback._load_and_cache`

- New security test suite validates oversized file rejection

- Updated existing tests to mock file sizes for compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Load Request"] --> B["Check File Size"]
  B --> C{Size <= 5MB?}
  C -->|Yes| D["Load into Memory"]
  C -->|No| E["Raise ValueError"]
  E --> F["Log Warning"]
  F --> G["Prevent Crash"]
  D --> H["Cache & Play"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add file size validation to audio loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implemented file size validation in <code>_load_and_cache</code> method<br> <li> Raises <code>ValueError</code> if audio file exceeds size limit before opening<br> <li> Prevents memory exhaustion by rejecting oversized files early</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/47/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Mock file sizes in audio feedback tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Updated <code>test_load_and_cache_sounddevice</code> to mock <code>Path.stat()</code> return <br>value<br> <li> Updated <code>test_load_and_cache_with_volume_scaling</code> to mock file size<br> <li> Ensures tests work with new file size validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/47/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>New security tests for audio file limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>New test file for audio security validation<br> <li> Tests that <code>_load_and_cache</code> raises <code>ValueError</code> for 6MB files<br> <li> Verifies size check occurs before file opening<br> <li> Confirms security check prevents oversized file loading</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/47/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentinel.md</strong><dd><code>Document audio file DoS vulnerability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/sentinel.md

<ul><li>Added journal entry documenting the audio file loading vulnerability<br> <li> Describes the DoS risk from unrestricted file loading<br> <li> Documents the learning and prevention strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/47/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

