### PR TITLE
⚡ Bolt: Minimize lock contention during model unload

### DIFF
--- a/src/chirp/parakeet_manager.py
+++ b/src/chirp/parakeet_manager.py
@@ -65,11 +65,15 @@ class ParakeetManager:
                 self._unload_model()
 
     def _unload_model(self) -> None:
+        should_collect = False
         with self._lock:
             if self._model is not None and (time.time() - self._last_access > self._timeout):
                 self._logger.info("Unloading Parakeet model to free memory.")
                 self._model = None
-                gc.collect()
+                should_collect = True
+        if should_collect:
+            # Perform GC outside the lock to avoid blocking other threads (e.g., transcribe requests)
+            gc.collect()
 
     def ensure_loaded(self):
         with self._lock:


### PR DESCRIPTION
### **User description**
Moved `gc.collect()` outside the thread lock in `ParakeetManager._unload_model`. 

💡 What:
Modified `_unload_model` to set a flag inside the lock and perform garbage collection outside of it.

🎯 Why:
`gc.collect()` is a blocking operation. Holding the `_lock` during GC prevents other threads (specifically `transcribe` which updates `last_access`) from acquiring the lock, potentially causing latency spikes or blocks.

📊 Impact:
Reduces blocking time for concurrent operations when the model is unloading.

🔬 Measurement:
Verified with existing unit tests `tests/test_parakeet_manager.py` to ensure lifecycle logic remains correct. The optimization is architectural (lock granularity) rather than micro-benchmarkable in a single thread test without simulated contention.

---
*PR created automatically by Jules for task [3629905722079250151](https://jules.google.com/task/3629905722079250151) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Move garbage collection outside lock in `_unload_model`

- Reduce lock contention for concurrent transcribe operations

- Minimize latency spikes during model unload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_unload_model called"] --> B["Set flag inside lock"]
  B --> C["Release lock"]
  C --> D["Perform gc.collect outside lock"]
  D --> E["Other threads can acquire lock"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parakeet_manager.py</strong><dd><code>Defer garbage collection outside lock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/parakeet_manager.py

<ul><li>Introduced <code>should_collect</code> flag to defer garbage collection<br> <li> Moved <code>gc.collect()</code> call outside the <code>_lock</code> critical section<br> <li> Added explanatory comment about avoiding thread blocking<br> <li> Maintains same unload logic while reducing lock hold time</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/48/files#diff-1e1157722142317b937daebf4aa7c4a920cfe67e018f405d8e5dd853155978e0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

