### PR TITLE
🎨 Palette: Add transcription status indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-31 - Visual Feedback for Long-Running CLI Tasks
+**Learning:** CLI users often feel uncertain during silent blocking operations (like AI model transcription).
+**Action:** Always wrap long-running tasks (>1s) in a `console.status(...)` context manager (using `rich`) to provide immediate visual assurance.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -53,16 +53,16 @@ class ChirpApp:
             volume=self.config.audio_feedback_volume,
         )
 
-        console = None
+        self.console = None
         for handler in self.logger.handlers:
             if isinstance(handler, RichHandler):
-                console = handler.console
+                self.console = handler.console
                 break
-        if not console:
-            console = Console(stderr=True)
+        if not self.console:
+            self.console = Console(stderr=True)
 
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -153,7 +153,8 @@ class ChirpApp:
             self.logger.warning("No audio samples captured")
             return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            with self.console.status("[bold yellow]Transcribing...[/bold yellow]", spinner="dots"):
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
         except Exception as exc:
             self.logger.exception("Transcription failed: %s", exc)
             self.audio_feedback.play_error(self.config.error_sound_path)

--- a/tests/test_chirp_ui.py
+++ b/tests/test_chirp_ui.py
@@ -1,0 +1,91 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+import types
+import numpy as np
+
+# Mock dependencies that are not available in the test environment
+if "sounddevice" not in sys.modules:
+    mock_sd = types.ModuleType("sounddevice")
+    mock_sd.InputStream = MagicMock()
+    sys.modules["sounddevice"] = mock_sd
+
+if "winsound" not in sys.modules:
+    mock_winsound = types.ModuleType("winsound")
+    sys.modules["winsound"] = mock_winsound
+
+from chirp.main import ChirpApp
+
+class TestChirpUI(unittest.TestCase):
+    @patch("chirp.main.ParakeetManager")
+    @patch("chirp.main.AudioCapture")
+    @patch("chirp.main.AudioFeedback")
+    @patch("chirp.main.KeyboardShortcutManager")
+    @patch("chirp.main.ConfigManager")
+    def test_transcription_status_indicator(self, mock_config, mock_keyboard, mock_feedback, mock_capture, mock_parakeet):
+        """Verify that the 'Transcribing...' status is shown during transcription."""
+
+        # Setup mock config
+        mock_config_instance = mock_config.return_value
+        mock_config_instance.load.return_value.parakeet_model = "test-model"
+        mock_config_instance.load.return_value.parakeet_quantization = None
+        mock_config_instance.load.return_value.onnx_providers = "cpu"
+        mock_config_instance.load.return_value.threads = 1
+        mock_config_instance.load.return_value.paste_mode = "ctrl"
+        mock_config_instance.load.return_value.word_overrides = {}
+        mock_config_instance.load.return_value.post_processing = ""
+        mock_config_instance.load.return_value.clipboard_behavior = False
+        mock_config_instance.load.return_value.clipboard_clear_delay = 1.0
+        mock_config_instance.load.return_value.max_recording_duration = 0
+        mock_config_instance.load.return_value.audio_feedback = False
+        mock_config_instance.load.return_value.model_timeout = 300.0
+        mock_config_instance.model_dir.return_value = "models/test-model"
+
+        # Mock ParakeetManager transcription
+        mock_parakeet_instance = mock_parakeet.return_value
+        mock_parakeet_instance.transcribe.return_value = "Test transcription"
+
+        # Mock Console and Status
+        mock_console = MagicMock()
+        mock_status = MagicMock()
+        mock_console.status.return_value.__enter__.return_value = mock_status
+
+        # We need to ensure that when ChirpApp is initialized, it uses our mock console.
+        # Since ChirpApp looks for RichHandler in logger.handlers, we can patch `get_logger`
+        # OR we can patch `Console` if ChirpApp creates a new one.
+        # However, ChirpApp logic is:
+        #   if RichHandler in logger.handlers -> use its console
+        #   else -> create new Console(stderr=True)
+        #
+        # Easier path: Patch Console globally, and ensure get_logger returns a logger without RichHandler.
+
+        with patch("chirp.main.get_logger") as mock_get_logger, \
+             patch("chirp.main.Console", return_value=mock_console) as mock_console_class:
+
+            # Setup logger mock to have no handlers so it falls back to creating a new Console
+            mock_logger = MagicMock()
+            mock_logger.handlers = []
+            mock_get_logger.return_value = mock_logger
+
+            # Initialize App
+            app = ChirpApp()
+
+            # Trigger transcription
+            waveform = np.zeros(16000)
+            app._transcribe_and_inject(waveform)
+
+            # Verify status was called with "Transcribing..."
+            # Note: app._transcribe_and_inject calls app.parakeet.transcribe
+            # We want to check that console.status("Transcribing...", spinner="dots") was entered.
+
+            status_calls = mock_console.status.call_args_list
+            transcribing_called = False
+            for args, kwargs in status_calls:
+                if "Transcribing..." in args[0] and kwargs.get("spinner") == "dots":
+                    transcribing_called = True
+                    break
+
+            self.assertTrue(transcribing_called, "Console status 'Transcribing...' was not triggered.")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
💡 What: Added a "Transcribing..." visual status indicator in the CLI.
🎯 Why: Users previously had no visual feedback during the transcription phase, leading to uncertainty about whether the app was working.
📸 Before/After: (CLI change) Before: Silent pause. After: Yellow "Transcribing..." spinner.
♿ Accessibility: Provides visual confirmation of background activity for sighted users relying on the terminal.

---
*PR created automatically by Jules for task [16728899072193721130](https://jules.google.com/task/16728899072193721130) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add visual "Transcribing..." status indicator during transcription

- Expose `self.console` in ChirpApp for consistent UI updates

- Add comprehensive UI tests for transcription status behavior

- Document learning about CLI user feedback patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp initialization"] -- "expose console" --> B["self.console instance"]
  C["_transcribe_and_inject method"] -- "wrap with status" --> D["console.status context"]
  D -- "shows spinner" --> E["Yellow Transcribing indicator"]
  F["Test suite"] -- "verifies" --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add transcription status indicator to ChirpApp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Refactored local <code>console</code> variable to instance variable <code>self.console</code> <br>for reusability<br> <li> Wrapped <code>parakeet.transcribe()</code> call with <code>console.status()</code> context <br>manager showing "Transcribing..." spinner<br> <li> Maintains existing console initialization logic from RichHandler or <br>creates new Console instance</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/49/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chirp_ui.py</strong><dd><code>Add UI tests for transcription status indicator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_chirp_ui.py

<ul><li>Created new test file for UI behavior verification<br> <li> Added <code>TestChirpUI</code> class with <code>test_transcription_status_indicator</code> test <br>method<br> <li> Mocks all ChirpApp dependencies (ParakeetManager, AudioCapture, <br>AudioFeedback, etc.)<br> <li> Verifies that <code>console.status()</code> is called with "Transcribing..." text <br>and "dots" spinner during transcription</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/49/files#diff-7c2cf2a4bc961d2c43f024ac59da168a8497fe6d838e41800b03619d04bfeacc">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document CLI feedback pattern learning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Documents learning about CLI user experience with long-running <br>operations<br> <li> Establishes pattern to wrap blocking tasks (>1s) with <code>console.status()</code> <br>for visual feedback<br> <li> Provides actionable guidance for future CLI enhancements</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/49/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

