### PR TITLE
⚡ Bolt: Preload audio feedback to minimize latency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-02-18 - Pre-scaled Audio Feedback
 **Learning:** AudioFeedback volume scaling was applied during every playback, causing unnecessary numpy overhead and latency.
 **Action:** Pre-calculate scaled audio during `_load_and_cache` to minimize `_play_cached` latency (from ~1ms to ~0.04ms).
+
+## 2024-05-22 - Preload Audio Assets
+**Learning:** Audio assets (start/stop/error sounds) were loaded lazily on first use, adding I/O latency (tens of ms) to the critical path of the first user interaction.
+**Action:** Added `preload_start/stop/error` to `AudioFeedback` and called them during `ChirpApp` initialization. This moves the I/O cost to app startup (where it is masked by model loading) and ensures instant feedback on first hotkey press.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -72,8 +72,14 @@ class AudioFeedback:
     def play_start(self, override_path: Optional[str] = None) -> None:
         self._play_sound("ping-up.wav", override_path)
 
+    def preload_start(self, override_path: Optional[str] = None) -> None:
+        self._ensure_cached("ping-up.wav", override_path)
+
     def play_stop(self, override_path: Optional[str] = None) -> None:
         self._play_sound("ping-down.wav", override_path)
+
+    def preload_stop(self, override_path: Optional[str] = None) -> None:
+        self._ensure_cached("ping-down.wav", override_path)
 
     def play_error(self, override_path: Optional[str] = None) -> None:
         """Play error sound. Uses custom path, or falls back to system beep."""
@@ -105,6 +111,24 @@ class AudioFeedback:
         else:
             # No system beep on non-Windows, just log
             self._logger.debug("No error sound available (no winsound, no custom path)")
+
+    def preload_error(self, override_path: Optional[str] = None) -> None:
+        if override_path:
+            self._ensure_cached("", override_path)
+
+    def _ensure_cached(self, asset_name: str, override_path: Optional[str]) -> None:
+        if not self._enabled:
+            return
+
+        cache_key = override_path or asset_name
+        if cache_key in self._cache:
+            return
+
+        try:
+            with self._get_sound_path(asset_name, override_path) as path:
+                self._load_and_cache(path, cache_key)
+        except Exception as exc:
+            self._logger.warning("Failed to preload sound %s: %s", cache_key, exc)
 
     def _play_sound(self, asset_name: str, override_path: Optional[str]) -> None:
         if not self._enabled:

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -53,6 +53,11 @@ class ChirpApp:
             volume=self.config.audio_feedback_volume,
         )
 
+        # Preload audio assets to minimize latency during interaction
+        self.audio_feedback.preload_start(self.config.start_sound_path)
+        self.audio_feedback.preload_stop(self.config.stop_sound_path)
+        self.audio_feedback.preload_error(self.config.error_sound_path)
+
         console = None
         for handler in self.logger.handlers:
             if isinstance(handler, RichHandler):


### PR DESCRIPTION
### **User description**
⚡ Bolt: Preload audio feedback to minimize latency

💡 **What:** Added logic to preload audio feedback assets (start/stop/error sounds) during application initialization.
🎯 **Why:** Previously, sounds were loaded lazily on first playback. This added I/O latency to the first "start recording" action, potentially causing the user to start speaking before the system was ready or feeling that the app was sluggish.
📊 **Impact:** Removes file I/O latency (tens of milliseconds) from the first user interaction.
🔬 **Measurement:** Verified with `verify_preload.py` that assets are cached before `play_start` is called. Existing tests pass.

---
*PR created automatically by Jules for task [1765130746846313085](https://jules.google.com/task/1765130746846313085) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Preload audio feedback assets during app initialization

- Moves I/O latency from critical user interaction path to startup phase

- Adds `preload_start`, `preload_stop`, `preload_error` methods to `AudioFeedback`

- Implements `_ensure_cached` helper to populate cache without playback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App Initialization"] --> B["Preload Audio Assets"]
  B --> C["Cache start/stop/error sounds"]
  C --> D["Instant feedback on user interaction"]
  E["User presses hotkey"] --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add audio asset preloading methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added three new preload methods: <code>preload_start</code>, <code>preload_stop</code>, <br><code>preload_error</code><br> <li> Implemented <code>_ensure_cached</code> helper method to load and cache audio <br>assets without playback<br> <li> Preload methods use existing cache mechanism to avoid redundant I/O <br>operations<br> <li> Error preload handles custom override paths gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/50/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Trigger audio preloading during app startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Call <code>preload_start</code>, <code>preload_stop</code>, <code>preload_error</code> during <br><code>ChirpApp.__init__</code><br> <li> Pass configured sound paths from config to preload methods<br> <li> Preloading happens after <code>AudioFeedback</code> initialization but before app <br>is ready</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/50/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document audio preloading optimization rationale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Added learning note documenting the audio asset preloading <br>optimization<br> <li> Explains the problem (lazy loading adds I/O latency to first <br>interaction)<br> <li> Documents the solution (preload during initialization, mask latency <br>with model loading)</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/50/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

