### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce audio file size limit to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Control characters could be injected via `word_overrides` configuration, bypassing initial input sanitization.
 **Learning:** Initial input sanitization is insufficient when configuration data (overrides) can re-introduce unsafe characters during processing.
 **Prevention:** Implement "Output Sanitization" as a final step in data processing pipelines. Ensure sanitization logic is reusable and safe (e.g., does not unintentionally destroy formatting like trailing whitespace unless intended).
+
+## 2025-05-21 - Security Documentation Drift
+**Vulnerability:** A documented 5MB audio file size limit was missing in the actual implementation, exposing the app to DoS via memory exhaustion.
+**Learning:** Security controls mentioned in documentation or developer memory may not exist or may have been regressed.
+**Prevention:** Verify all documented security controls with automated tests. Trust code, not docs.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -5,7 +5,7 @@ import platform
 import wave
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, Optional
 
 from importlib import resources
 
@@ -23,6 +23,9 @@ try:
     import winsound  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
+
+
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
 class AudioFeedback:
@@ -130,6 +133,11 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        if path.stat().st_size > MAX_AUDIO_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"Audio file too large: {path} (max {MAX_AUDIO_FILE_SIZE_BYTES} bytes)"
+            )
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -46,8 +46,10 @@ class TestAudioFeedback(unittest.TestCase):
     @patch("chirp.audio_feedback.sd")
     @patch("chirp.audio_feedback.np")
     @patch("chirp.audio_feedback.wave")
-    def test_load_and_cache_sounddevice(self, mock_wave, mock_np, mock_sd):
+    @patch("pathlib.Path.stat")
+    def test_load_and_cache_sounddevice(self, mock_stat, mock_wave, mock_np, mock_sd):
         """_load_and_cache should read WAV and cache data."""
+        mock_stat.return_value.st_size = 1000  # Valid size
         af = AudioFeedback(logger=self.mock_logger, enabled=True)
 
         # Setup wave mock
@@ -85,8 +87,10 @@ class TestAudioFeedback(unittest.TestCase):
     @patch("chirp.audio_feedback.np")
     @patch("chirp.audio_feedback.wave")
     @patch("chirp.audio_feedback.winsound", None)
-    def test_load_and_cache_with_volume_scaling(self, mock_wave, mock_np, mock_sd):
+    @patch("pathlib.Path.stat")
+    def test_load_and_cache_with_volume_scaling(self, mock_stat, mock_wave, mock_np, mock_sd):
         """_load_and_cache should scale audio when volume < 1.0."""
+        mock_stat.return_value.st_size = 1000  # Valid size
         import numpy as np
 
         # Create real numpy array for testing

--- a/tests/test_audio_feedback_cache.py
+++ b/tests/test_audio_feedback_cache.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from pathlib import Path
 import logging
 
 from chirp.audio_feedback import AudioFeedback

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,59 @@
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from chirp.audio_feedback import AudioFeedback, MAX_AUDIO_FILE_SIZE_BYTES
+
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+
+    @patch("chirp.audio_feedback.sd")
+    @patch("chirp.audio_feedback.np")
+    @patch("chirp.audio_feedback.wave")
+    @patch("pathlib.Path.stat")
+    def test_load_and_cache_large_file_raises_error(self, mock_stat, mock_wave, mock_np, mock_sd):
+        """Should raise ValueError if audio file exceeds size limit."""
+        # Mock file size > 5MB
+        mock_stat.return_value.st_size = MAX_AUDIO_FILE_SIZE_BYTES + 1
+
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+        # Force use_sounddevice to true to trigger the loading logic
+        af._use_sounddevice = True
+
+        with self.assertRaises(ValueError) as cm:
+            af._load_and_cache(Path("/fake/large_file.wav"), "key")
+
+        self.assertIn("Audio file too large", str(cm.exception))
+
+    @patch("chirp.audio_feedback.sd")
+    @patch("chirp.audio_feedback.np")
+    @patch("chirp.audio_feedback.wave")
+    @patch("pathlib.Path.stat")
+    def test_load_and_cache_valid_file_proceeds(self, mock_stat, mock_wave, mock_np, mock_sd):
+        """Should proceed if audio file is within size limit."""
+        # Mock file size <= 5MB
+        mock_stat.return_value.st_size = MAX_AUDIO_FILE_SIZE_BYTES
+
+        # Mock wave open stuff
+        mock_wf = MagicMock()
+        mock_wave.open.return_value.__enter__.return_value = mock_wf
+        mock_wf.readframes.return_value = b""
+        mock_wf.getnchannels.return_value = 1
+        mock_wf.getframerate.return_value = 16000
+        mock_wf.getnframes.return_value = 0
+
+        mock_np.frombuffer.return_value = MagicMock()
+
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+        af._use_sounddevice = True
+
+        try:
+            af._load_and_cache(Path("/fake/valid_file.wav"), "key")
+        except ValueError:
+            self.fail("_load_and_cache raised ValueError unexpectedly!")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
🛡️ Sentinel: [MEDIUM] Enforce audio file size limit to prevent DoS

🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length limits (DoS risk). The application allowed loading arbitrarily large audio files into memory via `AudioFeedback`, which could lead to memory exhaustion and application crash (Denial of Service).
🎯 Impact: A user or attacker with access to `config.toml` could specify a large file path, causing the application to crash due to OOM when `_load_and_cache` attempts to read the entire file into a numpy array.
🔧 Fix:
- Added `MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024` (5MB) constant in `src/chirp/audio_feedback.py`.
- Added a check in `_load_and_cache` using `path.stat().st_size` to reject files larger than 5MB.
- Updated existing tests to mock `pathlib.Path.stat`.
- Added new security tests in `tests/test_audio_security.py` to verify the limit is enforced.
✅ Verification:
- `uv run python -m unittest tests/test_audio_security.py` passes.
- `uv run python -m unittest discover tests` passes.


---
*PR created automatically by Jules for task [12653216208219232376](https://jules.google.com/task/12653216208219232376) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce 5MB file size limit on audio files to prevent DoS attacks

- Added validation in `_load_and_cache` to reject oversized files

- Created comprehensive security tests in `test_audio_security.py`

- Updated existing tests to mock `Path.stat` calls properly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Loading"] -->|Check file size| B["Size Validation"]
  B -->|Size > 5MB| C["Raise ValueError"]
  B -->|Size <= 5MB| D["Load and Cache"]
  C --> E["Prevent DoS"]
  D --> F["Normal Operation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add audio file size limit validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implemented file size validation in <code>_load_and_cache</code> method<br> <li> Raises <code>ValueError</code> if audio file exceeds size limit<br> <li> Removed unused imports from type hints</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/51/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Mock Path.stat in existing tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Added <code>@patch("pathlib.Path.stat")</code> decorator to two test methods<br> <li> Mocked <code>stat().st_size</code> to return valid file size (1000 bytes)<br> <li> Ensures tests work with new file size validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/51/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>Add audio file size security tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>New security test file with two test cases<br> <li> <code>test_load_and_cache_large_file_raises_error</code>: Verifies ValueError is <br>raised for files > 5MB<br> <li> <code>test_load_and_cache_valid_file_proceeds</code>: Verifies files <= 5MB load <br>successfully<br> <li> Imports and tests <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/51/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback_cache.py</strong><dd><code>Remove unused import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback_cache.py

- Removed unused `Path` import from pathlib


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/51/files#diff-5d94a71896d6e8d308f089ffae29fc293d3d18f9e25eb0864acb238813aa5ada">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentinel.md</strong><dd><code>Document security learning from DoS vulnerability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/sentinel.md

<ul><li>Added new security learning entry dated 2025-05-21<br> <li> Documents vulnerability of missing audio file size limit in <br>implementation<br> <li> Highlights risk of documentation drift in security controls<br> <li> Recommends automated testing to verify documented security controls</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/51/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

