### PR TITLE
🎨 Palette: Add visual status spinner for recording and transcription

### DIFF
--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -5,7 +5,7 @@ import platform
 import wave
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, Optional
 
 from importlib import resources
 

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -61,6 +61,9 @@ class ChirpApp:
         if not console:
             console = Console(stderr=True)
 
+        self.console = console
+        self.status_indicator = self.console.status("Ready", spinner="dots")
+
         try:
             with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
@@ -123,6 +126,8 @@ class ChirpApp:
             return
         self._recording = True
         self.audio_feedback.play_start(self.config.start_sound_path)
+        self.status_indicator.update("Recording...", spinner="dots")
+        self.status_indicator.start()
         self.logger.info("Recording started")
 
         if self.config.max_recording_duration > 0:
@@ -144,27 +149,32 @@ class ChirpApp:
         waveform = self.audio_capture.stop()
         self._recording = False
         self.audio_feedback.play_stop(self.config.stop_sound_path)
+        self.status_indicator.update("Transcribing...", spinner="dots")
         self.logger.info("Recording stopped (%s samples)", waveform.size)
         self._executor.submit(self._transcribe_and_inject, waveform)
 
     def _transcribe_and_inject(self, waveform) -> None:
-        start_time = time.perf_counter()
-        if waveform.size == 0:
-            self.logger.warning("No audio samples captured")
-            return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
-        except Exception as exc:
-            self.logger.exception("Transcription failed: %s", exc)
-            self.audio_feedback.play_error(self.config.error_sound_path)
-            return
-        duration = time.perf_counter() - start_time
-        self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
-        if not text.strip():
-            self.logger.info("Transcription empty; skipping paste")
-            return
-        self.logger.debug("Transcription: %s", text)
-        self.text_injector.inject(text)
+            start_time = time.perf_counter()
+            if waveform.size == 0:
+                self.logger.warning("No audio samples captured")
+                return
+            try:
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            except Exception as exc:
+                self.logger.exception("Transcription failed: %s", exc)
+                self.audio_feedback.play_error(self.config.error_sound_path)
+                return
+            duration = time.perf_counter() - start_time
+            self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
+            if not text.strip():
+                self.logger.info("Transcription empty; skipping paste")
+                return
+            self.logger.debug("Transcription: %s", text)
+            self.text_injector.inject(text)
+        finally:
+            if not self._recording:
+                self.status_indicator.stop()
 
     def _log_capture_status(self, message: str) -> None:
         self.logger.debug("Audio status: %s", message)

--- a/tests/test_audio_feedback_cache.py
+++ b/tests/test_audio_feedback_cache.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from pathlib import Path
 import logging
 
 from chirp.audio_feedback import AudioFeedback

--- a/tests/test_ui_status.py
+++ b/tests/test_ui_status.py
@@ -1,0 +1,106 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock sounddevice before importing chirp.main because it fails on import if PortAudio is missing
+sys.modules["sounddevice"] = MagicMock()
+sys.modules["winsound"] = MagicMock()
+
+import logging  # noqa: E402
+import unittest  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+from rich.logging import RichHandler  # noqa: E402
+
+from chirp.main import ChirpApp  # noqa: E402
+
+
+class TestChirpAppUI(unittest.TestCase):
+    @patch("chirp.main.get_logger")
+    @patch("chirp.main.ConfigManager")
+    @patch("chirp.main.KeyboardShortcutManager")
+    @patch("chirp.main.AudioCapture")
+    @patch("chirp.main.AudioFeedback")
+    @patch("chirp.main.ParakeetManager")
+    @patch("chirp.main.TextInjector")
+    @patch("chirp.main.Console")
+    # Removed RichHandler patch
+    def setUp(self, mock_console, mock_text_injector, mock_parakeet,
+              mock_audio_feedback, mock_audio_capture, mock_keyboard, mock_config, mock_get_logger):
+
+        # Setup mocks
+        self.mock_logger = MagicMock(spec=logging.Logger)
+        self.mock_logger.handlers = []
+        mock_get_logger.return_value = self.mock_logger
+
+        # Mock Config
+        mock_config_instance = mock_config.return_value
+        mock_config_instance.load.return_value = MagicMock(
+            parakeet_model="test-model",
+            parakeet_quantization=None,
+            onnx_providers="cpu",
+            threads=0,
+            paste_mode="ctrl",
+            audio_feedback=False,
+            word_overrides={},
+            post_processing="",
+            clipboard_behavior=False,
+            clipboard_clear_delay=0.0,
+            max_recording_duration=0,
+            error_sound_path="",
+            start_sound_path="",
+            stop_sound_path="",
+            language="en"
+        )
+
+        # Mock Console and Status
+        self.mock_console_instance = mock_console.return_value
+        self.mock_status = MagicMock()
+        self.mock_console_instance.status.return_value = self.mock_status
+
+        # Setup logger handlers to include a real RichHandler with our mock console
+        # We need to construct it carefully or just mock the isinstance check?
+        # Creating a real RichHandler requires a Console.
+        # We can pass our mock console to it.
+        real_handler = RichHandler(console=self.mock_console_instance)
+        self.mock_logger.handlers = [real_handler]
+
+        self.app = ChirpApp()
+
+        # Manually attach the status indicator since we haven't implemented it in __init__ yet.
+        self.app.status_indicator = self.mock_status
+
+    def test_init_creates_status(self):
+        # This test verifies that status was called during init
+        self.mock_console_instance.status.assert_called_with("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots")
+
+    def test_start_recording_updates_status(self):
+        self.app._start_recording()
+        self.mock_status.update.assert_called_with("Recording...", spinner="dots")
+        self.mock_status.start.assert_called_once()
+
+    def test_stop_recording_updates_status(self):
+        self.app._recording = True
+        self.app._executor = MagicMock()
+        self.app._stop_recording()
+        self.mock_status.update.assert_called_with("Transcribing...", spinner="dots")
+
+    def test_transcribe_stops_status_when_done(self):
+        waveform = MagicMock()
+        waveform.size = 100
+
+        self.app.parakeet = MagicMock()
+        self.app.parakeet.transcribe.return_value = "test"
+
+        self.app._recording = False
+        self.app._transcribe_and_inject(waveform)
+        self.mock_status.stop.assert_called_once()
+
+    def test_transcribe_does_not_stop_status_if_recording(self):
+        waveform = MagicMock()
+        waveform.size = 100
+
+        self.app.parakeet = MagicMock()
+        self.app.parakeet.transcribe.return_value = "test"
+
+        self.app._recording = True
+        self.app._transcribe_and_inject(waveform)
+        self.mock_status.stop.assert_not_called()


### PR DESCRIPTION
### **User description**
Implemented a visual status indicator using `rich.console.Status` to provide feedback during recording and transcription phases. This improves the user experience by clarifying the application state (Recording vs Transcribing vs Idle). Added unit tests to verify the behavior.

---
*PR created automatically by Jules for task [1523845753990020326](https://jules.google.com/task/1523845753990020326) started by @Whamp*


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add visual status spinner for recording and transcription phases

- Display "Recording..." during audio capture, "Transcribing..." during processing

- Stop spinner when transcription completes or fails

- Add comprehensive unit tests for UI status indicator behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp Init"] -- "creates status indicator" --> B["Status Indicator"]
  C["Start Recording"] -- "updates to Recording" --> B
  D["Stop Recording"] -- "updates to Transcribing" --> B
  E["Transcription Complete"] -- "stops spinner" --> B
  F["Transcription Error"] -- "stops spinner" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Integrate status spinner into recording workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Initialize <code>console</code> and <code>status_indicator</code> in <code>__init__</code> method<br> <li> Update status to "Recording..." when <code>_start_recording()</code> is called and <br>start spinner<br> <li> Update status to "Transcribing..." when <code>_stop_recording()</code> is called<br> <li> Add try-finally block in <code>_transcribe_and_inject()</code> to stop spinner on <br>completion or error<br> <li> Wrap transcription logic in try-finally to ensure spinner stops <br>regardless of outcome</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/52/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+26/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ui_status.py</strong><dd><code>Add unit tests for UI status indicator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_ui_status.py

<ul><li>Create new test file with comprehensive unit tests for UI status <br>indicator<br> <li> Test status initialization during app startup<br> <li> Test status updates during recording start and stop phases<br> <li> Test spinner stops after transcription completes or when recording <br>ends<br> <li> Mock all external dependencies including sounddevice and winsound <br>modules</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/52/files#diff-c127e8fbac40a9a34d6eea703f638535848f2dbdb36a06a59f634eacfeb31b7e">+106/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Clean up unused type imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

- Remove unused imports `Tuple` and `Union` from typing module


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/52/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback_cache.py</strong><dd><code>Remove unused import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback_cache.py

- Remove unused `Path` import from pathlib module


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/52/files#diff-5d94a71896d6e8d308f089ffae29fc293d3d18f9e25eb0864acb238813aa5ada">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

