### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded audio file read (DoS risk)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Control characters could be injected via `word_overrides` configuration, bypassing initial input sanitization.
 **Learning:** Initial input sanitization is insufficient when configuration data (overrides) can re-introduce unsafe characters during processing.
 **Prevention:** Implement "Output Sanitization" as a final step in data processing pipelines. Ensure sanitization logic is reusable and safe (e.g., does not unintentionally destroy formatting like trailing whitespace unless intended).
+
+## 2025-05-21 - Unbounded Resource Loading (DoS)
+**Vulnerability:** `AudioFeedback` loaded user-defined sound files entirely into memory without size checks.
+**Learning:** Local apps are still vulnerable to DoS via configuration if they blindly trust file paths to fit in memory.
+**Prevention:** Enforce strict file size limits (e.g., `MAX_AUDIO_FILE_SIZE_BYTES`) before opening user-provided files.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -5,7 +5,7 @@ import platform
 import wave
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, Optional
 
 from importlib import resources
 
@@ -23,6 +23,9 @@ try:
     import winsound  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
+
+
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
 
 
 class AudioFeedback:
@@ -130,6 +133,12 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        # Security check: prevent loading massive files (DoS)
+        if path.stat().st_size > MAX_AUDIO_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"Audio file {path} exceeds size limit of {MAX_AUDIO_FILE_SIZE_BYTES / 1024 / 1024:.1f}MB"
+            )
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -62,7 +62,10 @@ class TestAudioFeedback(unittest.TestCase):
         mock_np.frombuffer.return_value = mock_audio_data
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024  # Small size
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
         mock_wave.open.assert_called_with("/fake/sound.wav", "rb")
         mock_np.frombuffer.assert_called()
@@ -110,7 +113,10 @@ class TestAudioFeedback(unittest.TestCase):
         af = AudioFeedback(logger=self.mock_logger, enabled=True, volume=0.5)
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024  # Small size
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
         audio_data, samplerate = data
 

--- a/tests/test_audio_feedback_cache.py
+++ b/tests/test_audio_feedback_cache.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from pathlib import Path
 import logging
 
 from chirp.audio_feedback import AudioFeedback

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,44 @@
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from chirp.audio_feedback import AudioFeedback
+
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+
+    @patch("chirp.audio_feedback.sd", new=MagicMock())
+    @patch("chirp.audio_feedback.wave")
+    @patch("chirp.audio_feedback.np")
+    @patch("chirp.audio_feedback.winsound", None)
+    def test_rejects_large_files(self, mock_np, mock_wave):
+        """AudioFeedback should reject files larger than 5MB."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock Path.stat() to return a large size
+        with patch.object(Path, "stat") as mock_stat:
+            # 5MB + 1 byte
+            mock_stat.return_value.st_size = 5 * 1024 * 1024 + 1
+
+            # Mock wave.open to behave normally (if check fails, this would be called)
+            mock_wf = MagicMock()
+            mock_wave.open.return_value.__enter__.return_value = mock_wf
+            mock_wf.getframerate.return_value = 44100
+            mock_wf.getnchannels.return_value = 1
+            mock_wf.readframes.return_value = b"\x00"
+            mock_wf.getnframes.return_value = 1
+            mock_np.frombuffer.return_value = MagicMock()
+
+            # We expect ValueError. If the check is missing, this block will finish
+            # without raising ValueError (because we mocked wave.open), causing the test to fail.
+            with self.assertRaises(ValueError) as cm:
+                af._load_and_cache(Path("large_file.wav"), "key")
+
+            self.assertIn("exceeds size limit", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
Enforced a 5MB size limit on audio files loaded by `AudioFeedback` to prevent memory exhaustion (DoS).
Added `tests/test_audio_security.py` to verify the fix and updated `tests/test_audio_feedback.py` to mock `Path.stat` where necessary.

---
*PR created automatically by Jules for task [15511094910477066961](https://jules.google.com/task/15511094910477066961) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforces 5MB size limit on audio files to prevent DoS attacks

- Adds security check in `_load_and_cache` method before file loading

- Introduces new test suite `test_audio_security.py` for validation

- Updates existing tests to mock `Path.stat` for proper isolation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Loading"] --> B["Size Check"]
  B --> C{Size <= 5MB?}
  C -->|Yes| D["Load File"]
  C -->|No| E["Raise ValueError"]
  F["Security Tests"] --> G["Verify Rejection"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add file size limit validation for audio loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implemented file size validation in <code>_load_and_cache</code> method<br> <li> Raises <code>ValueError</code> if audio file exceeds size limit<br> <li> Removed unused imports (<code>Tuple</code>, <code>Union</code>) from type hints</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/53/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Mock Path.stat for audio loading tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Added <code>Path.stat</code> mocking in <code>test_load_and_cache_sounddevice</code> test<br> <li> Added <code>Path.stat</code> mocking in <code>test_load_and_cache_with_volume_scaling</code> <br>test<br> <li> Ensures tests pass with new size validation check</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/53/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>New security tests for audio file limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>New test file for audio security validation<br> <li> <code>test_rejects_large_files</code> verifies rejection of files exceeding 5MB <br>limit<br> <li> Mocks <code>Path.stat</code> to simulate oversized files<br> <li> Validates error message contains "exceeds size limit"</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/53/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback_cache.py</strong><dd><code>Remove unused import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback_cache.py

- Removed unused `Path` import from file


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/53/files#diff-5d94a71896d6e8d308f089ffae29fc293d3d18f9e25eb0864acb238813aa5ada">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentinel.md</strong><dd><code>Document audio file DoS vulnerability lesson</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/sentinel.md

<ul><li>Added documentation entry for unbounded resource loading vulnerability<br> <li> Documented learning about DoS risks in local apps with file loading<br> <li> Recorded prevention strategy using file size limits</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/53/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

