### PR TITLE
🎨 Palette: Add visual status indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,9 @@
+# Palette's Journal
+
+## 2024-05-23 - Visual Feedback in CLI
+**Learning:** Adding a persistent `rich.status.Status` indicator significantly improves perceived responsiveness in CLI apps that perform background tasks (like recording/transcribing).
+**Action:** When designing CLI tools with long-running or modal states (recording vs idle), always include a visual indicator of the current mode, ideally with color coding (Red for recording, Green for processing).
+
+## 2024-05-23 - Testing Rich Components
+**Learning:** Testing `rich` components (like `Status` or `Console`) often requires checking the *lifecycle* of calls (`start`, `stop`, `update`) rather than just the final state. Also, mocking `RichHandler` requires using the real class or a carefully constructed mock to pass `isinstance` checks.
+**Action:** Use `unittest.mock.call` to verify the sequence of UI updates, and instantiate real `RichHandler` objects with mock consoles for integration tests.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -53,16 +53,18 @@ class ChirpApp:
             volume=self.config.audio_feedback_volume,
         )
 
-        console = None
+        self.console = None
         for handler in self.logger.handlers:
             if isinstance(handler, RichHandler):
-                console = handler.console
+                self.console = handler.console
                 break
-        if not console:
-            console = Console(stderr=True)
+        if not self.console:
+            self.console = Console(stderr=True)
+
+        self.status_indicator = self.console.status("Ready")
 
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -122,6 +124,8 @@ class ChirpApp:
             self.audio_feedback.play_error(self.config.error_sound_path)
             return
         self._recording = True
+        self.status_indicator.update("[bold red]Recording...[/bold red]", spinner="point")
+        self.status_indicator.start()
         self.audio_feedback.play_start(self.config.start_sound_path)
         self.logger.info("Recording started")
 
@@ -143,28 +147,33 @@ class ChirpApp:
         self.logger.debug("Stopping audio capture")
         waveform = self.audio_capture.stop()
         self._recording = False
+        self.status_indicator.update("[bold green]Transcribing...[/bold green]", spinner="dots")
         self.audio_feedback.play_stop(self.config.stop_sound_path)
         self.logger.info("Recording stopped (%s samples)", waveform.size)
         self._executor.submit(self._transcribe_and_inject, waveform)
 
     def _transcribe_and_inject(self, waveform) -> None:
-        start_time = time.perf_counter()
-        if waveform.size == 0:
-            self.logger.warning("No audio samples captured")
-            return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
-        except Exception as exc:
-            self.logger.exception("Transcription failed: %s", exc)
-            self.audio_feedback.play_error(self.config.error_sound_path)
-            return
-        duration = time.perf_counter() - start_time
-        self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
-        if not text.strip():
-            self.logger.info("Transcription empty; skipping paste")
-            return
-        self.logger.debug("Transcription: %s", text)
-        self.text_injector.inject(text)
+            start_time = time.perf_counter()
+            if waveform.size == 0:
+                self.logger.warning("No audio samples captured")
+                return
+            try:
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            except Exception as exc:
+                self.logger.exception("Transcription failed: %s", exc)
+                self.audio_feedback.play_error(self.config.error_sound_path)
+                return
+            duration = time.perf_counter() - start_time
+            self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
+            if not text.strip():
+                self.logger.info("Transcription empty; skipping paste")
+                return
+            self.logger.debug("Transcription: %s", text)
+            self.text_injector.inject(text)
+        finally:
+            if not self._recording:
+                self.status_indicator.stop()
 
     def _log_capture_status(self, message: str) -> None:
         self.logger.debug("Audio status: %s", message)

--- a/tests/test_ui_status.py
+++ b/tests/test_ui_status.py
@@ -1,0 +1,100 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+# Mock dependencies before import
+sys.modules["sounddevice"] = MagicMock()
+sys.modules["keyboard"] = MagicMock()
+
+# Now we can import chirp.main
+from chirp.main import ChirpApp
+from rich.logging import RichHandler
+
+class TestUIStatus(unittest.TestCase):
+    @patch("chirp.main.ConfigManager")
+    @patch("chirp.main.get_logger")
+    @patch("chirp.main.ParakeetManager")
+    @patch("chirp.main.AudioCapture")
+    @patch("chirp.main.AudioFeedback")
+    @patch("chirp.main.TextInjector")
+    def test_status_indicator_lifecycle(
+        self,
+        MockTextInjector,
+        MockAudioFeedback,
+        MockAudioCapture,
+        MockParakeetManager,
+        MockGetLogger,
+        MockConfigManager,
+    ):
+        # Setup mocks
+        mock_logger = MagicMock()
+        mock_console = MagicMock()
+
+        # Configure console.status to return different mocks for different calls if needed,
+        # or just reuse the same one. For simplicity, let's reuse, but distinct calls matter.
+        # Let's verify calls were made.
+
+        handler = RichHandler(console=mock_console)
+        mock_logger.handlers = [handler]
+
+        MockGetLogger.return_value = mock_logger
+
+        # Setup Config
+        mock_config = MockConfigManager.return_value.load.return_value
+        mock_config.parakeet_model = "test-model"
+        mock_config.parakeet_quantization = None
+        mock_config.onnx_providers = "cpu"
+        mock_config.threads = 1
+        mock_config.audio_feedback = False
+        mock_config.max_recording_duration = 0
+        mock_config.model_timeout = 300
+        mock_config.paste_mode = "ctrl"
+        mock_config.word_overrides = {}
+        mock_config.post_processing = ""
+        mock_config.clipboard_behavior = False
+        mock_config.clipboard_clear_delay = 0.5
+        mock_config.start_sound_path = ""
+        mock_config.stop_sound_path = ""
+        mock_config.error_sound_path = ""
+        mock_config.primary_shortcut = "ctrl+space"
+        mock_config.language = "en"
+
+        app = ChirpApp()
+
+        # Verify initialization
+        self.assertEqual(app.console, mock_console)
+
+        # Verify "Ready" status was requested
+        # We expect a call to status("Ready")
+        mock_console.status.assert_any_call("Ready")
+
+        status_mock = app.status_indicator
+
+        # Test Start Recording
+        app._start_recording()
+        status_mock.update.assert_called_with("[bold red]Recording...[/bold red]", spinner="point")
+        status_mock.start.assert_called()
+
+        # Test Stop Recording
+        app._stop_recording()
+        status_mock.update.assert_called_with("[bold green]Transcribing...[/bold green]", spinner="dots")
+
+        # Test Transcribe (simulate thread execution)
+        waveform = MagicMock()
+        waveform.size = 100
+
+        # Case 1: finish transcription and not recording
+        app._recording = False
+        app._transcribe_and_inject(waveform)
+        status_mock.stop.assert_called()
+
+        # Reset mocks
+        status_mock.stop.reset_mock()
+
+        # Case 2: finish transcription but recording started again
+        app._recording = True
+        app._transcribe_and_inject(waveform)
+        status_mock.stop.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
This PR adds a visual status indicator to the Chirp CLI application. Previously, the user only received log messages ("Recording started", "Recording stopped"). Now, a persistent spinner provides immediate feedback on the application's state (Recording vs. Transcribing/Idle).

Changes:
- Modified `ChirpApp` in `src/chirp/main.py` to initialize and manage a `self.status_indicator` using `rich.console.Status`.
- Updated `_start_recording`, `_stop_recording`, and `_transcribe_and_inject` to update the status text and spinner style.
- Added `tests/test_ui_status.py` to verify the UI lifecycle and ensure thread safety logic works as expected.


---
*PR created automatically by Jules for task [12855048616214424341](https://jules.google.com/task/12855048616214424341) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add persistent visual status indicator with spinner to CLI

- Show recording state in red and transcribing state in green

- Handle concurrent recording sessions with proper spinner lifecycle

- Add comprehensive unit tests for status indicator behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp Init"] -->|"Create status_indicator"| B["Status Ready"]
  C["Start Recording"] -->|"Update to Recording"| D["Red Spinner Point"]
  E["Stop Recording"] -->|"Update to Transcribing"| F["Green Spinner Dots"]
  G["Transcribe Complete"] -->|"Check _recording flag"| H["Stop Spinner"]
  H -->|"If not recording"| I["Status Stopped"]
  H -->|"If recording"| J["Keep Running"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add status indicator lifecycle management to recording workflow</code></dd></summary>
<hr>

src/chirp/main.py

<ul><li>Convert local <code>console</code> variable to instance variable <code>self.console</code> for <br>persistent access<br> <li> Initialize <code>self.status_indicator</code> with "Ready" status at startup<br> <li> Update <code>_start_recording()</code> to display red "Recording..." spinner with <br>"point" style<br> <li> Update <code>_stop_recording()</code> to display green "Transcribing..." spinner <br>with "dots" style<br> <li> Wrap <code>_transcribe_and_inject()</code> logic in try-finally block to stop <br>spinner when transcription completes and no new recording is active</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/55/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+30/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ui_status.py</strong><dd><code>Add unit tests for status indicator lifecycle and concurrency</code></dd></summary>
<hr>

tests/test_ui_status.py

<ul><li>Create comprehensive unit test suite for status indicator <br>functionality<br> <li> Mock all dependencies including ConfigManager, ParakeetManager, <br>AudioCapture, and AudioFeedback<br> <li> Verify status indicator initialization with "Ready" state<br> <li> Test status updates during recording start with red spinner<br> <li> Test status updates during recording stop with green spinner<br> <li> Test spinner lifecycle: stops when transcription completes if not <br>recording, continues if new recording started</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/55/files#diff-c127e8fbac40a9a34d6eea703f638535848f2dbdb36a06a59f634eacfeb31b7e">+100/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document learnings on CLI visual feedback and testing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Document learning about persistent visual feedback in CLI applications<br> <li> Record insights on color-coding modal states (red for recording, green <br>for processing)<br> <li> Document testing approach for rich components focusing on lifecycle <br>verification<br> <li> Capture best practices for mocking RichHandler with real class <br>instantiation</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/55/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

