### PR TITLE
🛡️ Sentinel: Fix Unbounded File Read in AudioFeedback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Control characters could be injected via `word_overrides` configuration, bypassing initial input sanitization.
 **Learning:** Initial input sanitization is insufficient when configuration data (overrides) can re-introduce unsafe characters during processing.
 **Prevention:** Implement "Output Sanitization" as a final step in data processing pipelines. Ensure sanitization logic is reusable and safe (e.g., does not unintentionally destroy formatting like trailing whitespace unless intended).
+
+## 2025-05-21 - Unbounded File Read in AudioFeedback
+**Vulnerability:** `AudioFeedback._load_and_cache` read entire audio files into memory without size limits, allowing potential DoS via memory exhaustion if a user (or attacker via config) pointed to a very large file.
+**Learning:** Loading external assets (even local ones) based on configuration requires validation of resource limits (size, type) to prevent resource exhaustion. Implicit trust in local file paths is risky if configuration can be shared or modified.
+**Prevention:** Enforce strict file size limits (e.g., 5MB) before reading files into memory. Use `path.stat().st_size` for a cheap pre-check.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -25,6 +25,9 @@ except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
 
 
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
+
+
 class AudioFeedback:
     def __init__(
         self,
@@ -130,6 +133,11 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        if path.stat().st_size > MAX_AUDIO_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"Audio file {path} ({path.stat().st_size} bytes) exceeds size limit of {MAX_AUDIO_FILE_SIZE_BYTES} bytes"
+            )
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -62,7 +62,9 @@ class TestAudioFeedback(unittest.TestCase):
         mock_np.frombuffer.return_value = mock_audio_data
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
         mock_wave.open.assert_called_with("/fake/sound.wav", "rb")
         mock_np.frombuffer.assert_called()
@@ -110,7 +112,9 @@ class TestAudioFeedback(unittest.TestCase):
         af = AudioFeedback(logger=self.mock_logger, enabled=True, volume=0.5)
 
         key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
         audio_data, samplerate = data
 

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,61 @@
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from chirp.audio_feedback import AudioFeedback
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+
+    @patch("chirp.audio_feedback.sd")
+    @patch("chirp.audio_feedback.winsound", None)
+    @patch("chirp.audio_feedback.wave")
+    @patch("chirp.audio_feedback.np")
+    def test_load_large_file_raises_error(self, mock_np, mock_wave, mock_sd):
+        """Should raise ValueError if audio file is too large."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Setup basic wave mock to avoid TypeError if check is missing
+        mock_wf = MagicMock()
+        mock_wave.open.return_value.__enter__.return_value = mock_wf
+        mock_wf.getnchannels.return_value = 1
+        mock_wf.getframerate.return_value = 44100
+        mock_wf.readframes.return_value = b""
+        mock_np.frombuffer.return_value = MagicMock()
+
+        # Mock file size > 5MB
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 6 * 1024 * 1024  # 6MB
+
+            with self.assertRaises(ValueError) as cm:
+                af._load_and_cache(Path("/fake/huge.wav"), "test_key")
+
+            self.assertIn("exceeds size limit", str(cm.exception))
+
+    @patch("chirp.audio_feedback.sd")
+    @patch("chirp.audio_feedback.winsound", None)
+    @patch("chirp.audio_feedback.wave")
+    @patch("chirp.audio_feedback.np")
+    def test_load_valid_file_size(self, mock_np, mock_wave, mock_sd):
+        """Should succeed if audio file is within size limit."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock valid file size
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = 1024  # 1KB
+
+            # Setup wave mock to return dummy data
+            mock_wf = MagicMock()
+            mock_wave.open.return_value.__enter__.return_value = mock_wf
+            mock_wf.getnchannels.return_value = 1
+            mock_wf.getframerate.return_value = 44100
+            mock_wf.readframes.return_value = b"\x00"
+            mock_np.frombuffer.return_value = MagicMock()
+
+            # Should not raise
+            af._load_and_cache(Path("/fake/small.wav"), "test_key")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
🛡️ Sentinel: [CRITICAL/HIGH] Fix Unbounded File Read in AudioFeedback

🚨 Severity: HIGH
💡 Vulnerability: `AudioFeedback` loaded audio files into memory without size checks, allowing DoS via memory exhaustion if configured with a large file.
🎯 Impact: Application crash or freeze due to OOM if `start_sound_path` or other audio config points to a large file (maliciously or accidentally).
🔧 Fix: Enforced a 5MB limit on audio files.
✅ Verification: New test `tests/test_audio_security.py` verifies that files > 5MB raise a ValueError and are not loaded.

---
*PR created automatically by Jules for task [90848794572746082](https://jules.google.com/task/90848794572746082) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce 5MB size limit on audio files to prevent DoS via memory exhaustion

- Add file size validation in `_load_and_cache` method before loading audio

- Create comprehensive security test suite for audio file handling

- Update existing tests to mock file size for compatibility

- Document security learning in sentinel knowledge base


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File"] -->|"stat().st_size check"| B["Size Validation"]
  B -->|"≤ 5MB"| C["Load & Cache"]
  B -->|"> 5MB"| D["Raise ValueError"]
  C --> E["Play Sound"]
  D --> F["Log Error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add file size validation for audio files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Add <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implement file size check in <code>_load_and_cache</code> method using <br><code>path.stat().st_size</code><br> <li> Raise <code>ValueError</code> with descriptive message if file exceeds size limit</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/56/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Update tests to mock file size validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Mock <code>Path.stat()</code> in <code>test_load_and_cache_sounddevice</code> to return 1024 <br>bytes<br> <li> Mock <code>Path.stat()</code> in <code>test_load_and_cache_with_volume_scaling</code> to return <br>1024 bytes<br> <li> Ensure existing tests work with new file size validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/56/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>Add security tests for audio file size limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>Create new security test file with <code>TestAudioSecurity</code> class<br> <li> Add <code>test_load_large_file_raises_error</code> to verify files > 5MB raise <br><code>ValueError</code><br> <li> Add <code>test_load_valid_file_size</code> to verify files ≤ 5MB load successfully<br> <li> Mock file system operations and dependencies for isolated testing</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/56/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentinel.md</strong><dd><code>Document audio file security vulnerability and prevention</code></dd></summary>
<hr>

.jules/sentinel.md

<ul><li>Document unbounded file read vulnerability in <br><code>AudioFeedback._load_and_cache</code><br> <li> Record security learning about implicit trust in local file paths<br> <li> Add prevention guidance on enforcing file size limits before loading <br>assets</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/56/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

