### PR TITLE
⚡ Bolt: Reduce lock contention in ParakeetManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-02-18 - Pre-scaled Audio Feedback
 **Learning:** AudioFeedback volume scaling was applied during every playback, causing unnecessary numpy overhead and latency.
 **Action:** Pre-calculate scaled audio during `_load_and_cache` to minimize `_play_cached` latency (from ~1ms to ~0.04ms).
+
+## 2026-02-03 - ParakeetManager Lock Contention
+**Learning:** `ParakeetManager._unload_model` held the thread lock during `gc.collect()`, potentially blocking concurrent inference requests.
+**Action:** Released the lock before invoking garbage collection to minimize the critical section duration.

--- a/src/chirp/parakeet_manager.py
+++ b/src/chirp/parakeet_manager.py
@@ -65,11 +65,15 @@ class ParakeetManager:
                 self._unload_model()
 
     def _unload_model(self) -> None:
+        should_gc = False
         with self._lock:
             if self._model is not None and (time.time() - self._last_access > self._timeout):
                 self._logger.info("Unloading Parakeet model to free memory.")
                 self._model = None
-                gc.collect()
+                should_gc = True
+
+        if should_gc:
+            gc.collect()
 
     def ensure_loaded(self):
         with self._lock:


### PR DESCRIPTION
### **User description**
⚡ Bolt: Reduce lock contention in ParakeetManager

💡 What:
Refactored `ParakeetManager._unload_model` to release the thread lock before invoking `gc.collect()`.

🎯 Why:
`gc.collect()` is a blocking operation that can take a significant amount of time. Calling it while holding the lock prevents other threads (specifically the main thread attempting `ensure_loaded` or `transcribe`) from acquiring the lock, leading to unnecessary latency spikes if a request coincides with the unload check.

📊 Impact:
Reduces the critical section duration during model unloading. While `gc.collect()` still impacts the process (GIL), releasing the specific `ParakeetManager` lock allows other threads to proceed as far as the GIL allows, rather than being blocked on an application-level mutex.

🔬 Measurement:
Verified via `tests/test_parakeet_manager.py` that the model is still correctly unloaded (set to `None`). No functional regressions found.

---
*PR created automatically by Jules for task [11316606292119827467](https://jules.google.com/task/11316606292119827467) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored `_unload_model` to release lock before `gc.collect()`

- Reduces critical section duration during model unloading

- Prevents garbage collection from blocking concurrent requests

- Documented optimization in `.jules/bolt.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_unload_model called"] --> B["Acquire lock"]
  B --> C["Set model to None"]
  C --> D["Release lock"]
  D --> E["Call gc.collect"]
  E --> F["Other threads can proceed"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parakeet_manager.py</strong><dd><code>Move gc.collect outside lock block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/parakeet_manager.py

<ul><li>Moved <code>gc.collect()</code> outside the <code>with self._lock:</code> block<br> <li> Introduced <code>should_gc</code> flag to track when garbage collection is needed<br> <li> Lock is now released before the blocking garbage collection operation<br> <li> Allows concurrent threads to acquire the lock while GC runs</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/57/files#diff-1e1157722142317b937daebf4aa7c4a920cfe67e018f405d8e5dd853155978e0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document ParakeetManager lock optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Added new optimization entry dated 2026-02-03<br> <li> Documented the ParakeetManager lock contention issue<br> <li> Explained the solution of releasing lock before garbage collection</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/57/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

