### PR TITLE
🎨 Palette: Add persistent CLI status indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Async Status Indicators
+**Learning:** When using `rich.console.Status` in an event-driven app with background threads, simple `start()`/`stop()` calls can cause race conditions. If a background task finishes and calls `stop()` while the main thread has already started a new state (e.g. "Recording..."), the UI breaks.
+**Action:** Always guard `status.stop()` in background threads with a state check (e.g. `if not self.active: status.stop()`) to ensure we don't clear a valid, newer status.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -53,16 +53,18 @@ class ChirpApp:
             volume=self.config.audio_feedback_volume,
         )
 
-        console = None
+        self.console = None
         for handler in self.logger.handlers:
             if isinstance(handler, RichHandler):
-                console = handler.console
+                self.console = handler.console
                 break
-        if not console:
-            console = Console(stderr=True)
+        if not self.console:
+            self.console = Console(stderr=True)
+
+        self.status_indicator = self.console.status("Idle")
 
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -125,6 +127,9 @@ class ChirpApp:
         self.audio_feedback.play_start(self.config.start_sound_path)
         self.logger.info("Recording started")
 
+        self.status_indicator.update("[bold red]Recording...[/bold red]", spinner="point")
+        self.status_indicator.start()
+
         if self.config.max_recording_duration > 0:
             self._stop_timer = threading.Timer(
                 self.config.max_recording_duration, self._handle_timeout
@@ -145,26 +150,34 @@ class ChirpApp:
         self._recording = False
         self.audio_feedback.play_stop(self.config.stop_sound_path)
         self.logger.info("Recording stopped (%s samples)", waveform.size)
+
+        self.status_indicator.update("[bold green]Transcribing...[/bold green]", spinner="dots")
+
         self._executor.submit(self._transcribe_and_inject, waveform)
 
     def _transcribe_and_inject(self, waveform) -> None:
-        start_time = time.perf_counter()
-        if waveform.size == 0:
-            self.logger.warning("No audio samples captured")
-            return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
-        except Exception as exc:
-            self.logger.exception("Transcription failed: %s", exc)
-            self.audio_feedback.play_error(self.config.error_sound_path)
-            return
-        duration = time.perf_counter() - start_time
-        self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
-        if not text.strip():
-            self.logger.info("Transcription empty; skipping paste")
-            return
-        self.logger.debug("Transcription: %s", text)
-        self.text_injector.inject(text)
+            start_time = time.perf_counter()
+            if waveform.size == 0:
+                self.logger.warning("No audio samples captured")
+                return
+            try:
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            except Exception as exc:
+                self.logger.exception("Transcription failed: %s", exc)
+                self.audio_feedback.play_error(self.config.error_sound_path)
+                return
+            duration = time.perf_counter() - start_time
+            self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
+            if not text.strip():
+                self.logger.info("Transcription empty; skipping paste")
+                return
+            self.logger.debug("Transcription: %s", text)
+            self.text_injector.inject(text)
+        finally:
+            # Only stop the status if we haven't started a new recording in the meantime.
+            if not self._recording:
+                self.status_indicator.stop()
 
     def _log_capture_status(self, message: str) -> None:
         self.logger.debug("Audio status: %s", message)

--- a/tests/test_ui_status.py
+++ b/tests/test_ui_status.py
@@ -1,0 +1,116 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import types
+
+# Mock sounddevice globally because it's missing in the test environment
+# and imported at top-level by chirp.audio_capture
+if "sounddevice" not in sys.modules:
+    mock_sd = types.ModuleType("sounddevice")
+    mock_sd.InputStream = MagicMock()
+    sys.modules["sounddevice"] = mock_sd
+
+# Mock winsound if on Windows
+if sys.platform == "win32" and "winsound" not in sys.modules:
+    mock_winsound = types.ModuleType("winsound")
+    sys.modules["winsound"] = mock_winsound
+
+# Mock keyboard (imported by main.py -> keyboard_shortcuts.py)
+if "keyboard" not in sys.modules:
+    mock_keyboard_lib = types.ModuleType("keyboard")
+    sys.modules["keyboard"] = mock_keyboard_lib
+
+# Mock pyperclip (imported by text_injector.py)
+if "pyperclip" not in sys.modules:
+    mock_pyperclip = types.ModuleType("pyperclip")
+    mock_pyperclip.copy = MagicMock()
+    mock_pyperclip.paste = MagicMock()
+    mock_pyperclip.PyperclipException = Exception
+    sys.modules["pyperclip"] = mock_pyperclip
+
+from chirp.main import ChirpApp
+
+class TestUIStatus(unittest.TestCase):
+    @patch("chirp.main.ParakeetManager")
+    @patch("chirp.main.AudioCapture")
+    @patch("chirp.main.AudioFeedback")
+    @patch("chirp.main.KeyboardShortcutManager")
+    @patch("chirp.main.ConfigManager")
+    @patch("chirp.main.Console")
+    @patch("chirp.main.get_logger")
+    def test_status_lifecycle(self, mock_get_logger, MockConsole, MockConfigManager, MockKeyboard, MockAudioFeedback, MockAudioCapture, MockParakeet):
+        # Setup mocks
+        mock_console_instance = MockConsole.return_value
+        mock_status = MagicMock()
+        mock_console_instance.status.return_value = mock_status
+
+        # Mock logger to ensure no handlers so ChirpApp uses patched Console
+        mock_logger = MagicMock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+
+        # Mock config
+        mock_config = MockConfigManager.return_value.load.return_value
+        mock_config.parakeet_model = "test-model"
+        mock_config.audio_feedback = True
+        mock_config.error_sound_path = None
+        mock_config.start_sound_path = None
+        mock_config.stop_sound_path = None
+        mock_config.max_recording_duration = 0
+        mock_config.clipboard_clear_delay = 0.5
+        mock_config.paste_mode = "ctrl"
+        mock_config.word_overrides = {}
+        mock_config.post_processing = ""
+        mock_config.clipboard_behavior = False
+        mock_config.threads = 1
+        mock_config.onnx_providers = "cpu"
+        mock_config.parakeet_quantization = None
+        mock_config.model_timeout = 300.0
+        mock_config.language = "en"
+        mock_config.primary_shortcut = "ctrl+space"
+
+        # Initialize app
+        app = ChirpApp()
+
+        # Verify status created (but not necessarily started for idle, or maybe "Idle" status created)
+        # In my plan: self.status_indicator = self.console.status("Idle")
+        mock_console_instance.status.assert_any_call("Idle")
+
+        # Reset mock to clear initialization calls
+        mock_status.reset_mock()
+
+        # 1. Start Recording
+        app._start_recording()
+
+        # Verify status updated to recording
+        mock_status.update.assert_called_with("[bold red]Recording...[/bold red]", spinner="point")
+        mock_status.start.assert_called()
+
+        # 2. Stop Recording
+        # Mock waveform
+        mock_waveform = MagicMock()
+        mock_waveform.size = 16000
+        app.audio_capture.stop.return_value = mock_waveform
+
+        app._stop_recording()
+
+        # Verify status updated to transcribing
+        mock_status.update.assert_called_with("[bold green]Transcribing...[/bold green]", spinner="dots")
+
+        # 3. Transcribe
+        # This is usually called by executor, but we call directly for test
+        app._transcribe_and_inject(mock_waveform)
+
+        # Verify status stopped
+        mock_status.stop.assert_called()
+
+        # 4. Race condition check: If recording started again during transcribe
+        mock_status.reset_mock()
+        app._recording = True
+        app._transcribe_and_inject(mock_waveform)
+
+        # Verify status was NOT stopped
+        mock_status.stop.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
This PR adds a persistent CLI status indicator to the Chirp application. Previously, the user only received log messages (INFO level) when recording started or stopped. Now, a spinner clearly indicates the current state: "Recording..." or "Transcribing...".

Key changes:
- `src/chirp/main.py`: Added `self.status_indicator` to `ChirpApp` and integrated it into the recording/transcription loop.
- `tests/test_ui_status.py`: Added comprehensive unit tests for the status logic, including race condition verification.

The implementation ensures that if a user starts a new recording while a previous transcription is finishing, the "Recording..." status is preserved.

---
*PR created automatically by Jules for task [14825740349080691076](https://jules.google.com/task/14825740349080691076) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add persistent CLI status indicator with recording/transcribing states

- Implement race condition protection for background transcription tasks

- Update status display with visual spinners (red point, green dots)

- Add comprehensive unit tests for status lifecycle and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp Init"] -- "creates" --> B["Status Indicator"]
  C["Start Recording"] -- "updates to" --> D["Recording... Red Point"]
  D -- "user stops" --> E["Stop Recording"]
  E -- "updates to" --> F["Transcribing... Green Dots"]
  F -- "background task" --> G["Check if Recording"]
  G -- "not recording" --> H["Stop Status"]
  G -- "recording started" --> I["Keep Status Active"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Integrate persistent status indicator with race condition protection</code></dd></summary>
<hr>

src/chirp/main.py

<ul><li>Convert local <code>console</code> variable to instance variable <code>self.console</code> for <br>persistent access<br> <li> Add <code>self.status_indicator</code> initialized with "Idle" status on app <br>startup<br> <li> Update <code>_start_recording()</code> to display "Recording..." with red point <br>spinner and start status<br> <li> Update <code>_stop_recording()</code> to display "Transcribing..." with green dots <br>spinner<br> <li> Wrap <code>_transcribe_and_inject()</code> logic in try-finally block to guard <br><code>status.stop()</code> with <code>if not self._recording</code> check, preventing race <br>conditions where background transcription clears status of newly <br>started recording</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/58/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+34/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ui_status.py</strong><dd><code>Add unit tests for status indicator lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_ui_status.py

<ul><li>Create comprehensive unit test file for status indicator functionality<br> <li> Mock external dependencies (sounddevice, keyboard, pyperclip, <br>winsound) at module level<br> <li> Test status lifecycle: initialization, recording start, recording <br>stop, transcription completion<br> <li> Verify race condition handling: confirm status is not stopped if <br>recording restarts during transcription<br> <li> Use MagicMock to verify correct status update calls with proper <br>spinner types</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/58/files#diff-c127e8fbac40a9a34d6eea703f638535848f2dbdb36a06a59f634eacfeb31b7e">+116/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document race condition handling pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Document learning about race conditions with <code>rich.console.Status</code> in <br>event-driven apps with background threads<br> <li> Record solution pattern: guard <code>status.stop()</code> calls with state checks <br>to prevent clearing valid newer status<br> <li> Capture architectural insight for future reference</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/58/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

