### PR TITLE
⚡ Bolt: Release lock before GC in ParakeetManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-02-18 - Pre-scaled Audio Feedback
 **Learning:** AudioFeedback volume scaling was applied during every playback, causing unnecessary numpy overhead and latency.
 **Action:** Pre-calculate scaled audio during `_load_and_cache` to minimize `_play_cached` latency (from ~1ms to ~0.04ms).
+
+## 2025-05-18 - Unlocked Garbage Collection
+**Learning:** `ParakeetManager` held the model lock during `gc.collect()`, forcing concurrent `transcribe` requests (which require the lock) to wait for full GC completion before they could even *start* reloading the model.
+**Action:** Release the lock before calling `gc.collect()`. This allows `transcribe` to acquire the lock and begin `load_model` (which releases GIL for C++ ops) in parallel with the garbage collection of the old model.

--- a/src/chirp/parakeet_manager.py
+++ b/src/chirp/parakeet_manager.py
@@ -65,11 +65,15 @@ class ParakeetManager:
                 self._unload_model()
 
     def _unload_model(self) -> None:
+        should_collect = False
         with self._lock:
             if self._model is not None and (time.time() - self._last_access > self._timeout):
                 self._logger.info("Unloading Parakeet model to free memory.")
                 self._model = None
-                gc.collect()
+                should_collect = True
+
+        if should_collect:
+            gc.collect()
 
     def ensure_loaded(self):
         with self._lock:


### PR DESCRIPTION
### **User description**
💡 What: Moved `gc.collect()` outside of the `with self._lock:` block in `ParakeetManager._unload_model`.
🎯 Why: `gc.collect()` can be slow. Holding the lock during GC prevented other threads (e.g., a user starting a transcription) from acquiring the lock to reload the model, effectively serializing the wait time.
📊 Impact: Reduces potential latency when a user resumes activity exactly when the model is being unloaded.
🔬 Measurement: Verified via code inspection and unit tests ensuring lifecycle correctness is maintained.


---
*PR created automatically by Jules for task [5569431470742862643](https://jules.google.com/task/5569431470742862643) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Release thread lock before garbage collection in ParakeetManager

- Prevents GC from blocking concurrent transcribe requests waiting for lock

- Allows model reload to start in parallel with garbage collection

- Reduces latency when user resumes activity during model unload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_unload_model called"] --> B["Acquire lock"]
  B --> C["Set model to None"]
  C --> D["Release lock"]
  D --> E["Call gc.collect"]
  E --> F["GC completes"]
  D --> G["transcribe can acquire lock"]
  G --> H["Load new model in parallel"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Performance optimization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parakeet_manager.py</strong><dd><code>Move garbage collection outside lock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/parakeet_manager.py

<ul><li>Moved <code>gc.collect()</code> call outside the <code>with self._lock:</code> block in <br><code>_unload_model</code> method<br> <li> Introduced <code>should_collect</code> flag to track when garbage collection is <br>needed<br> <li> Lock is now released before garbage collection, allowing other threads <br>to acquire it<br> <li> Maintains lifecycle correctness while improving concurrency</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/59/files#diff-1e1157722142317b937daebf4aa7c4a920cfe67e018f405d8e5dd853155978e0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bolt.md</strong><dd><code>Document garbage collection lock optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/bolt.md

<ul><li>Added new learning entry documenting the lock contention issue with <br>garbage collection<br> <li> Documented the solution of releasing lock before <code>gc.collect()</code> to <br>enable parallel operations<br> <li> Explains how this allows <code>transcribe</code> to reload model while GC runs</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/59/files#diff-b3d690d8d9366d3902c26b045ee8782b86e79c27d6af7770d085989e65198f63">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

