### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in AudioFeedback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Control characters could be injected via `word_overrides` configuration, bypassing initial input sanitization.
 **Learning:** Initial input sanitization is insufficient when configuration data (overrides) can re-introduce unsafe characters during processing.
 **Prevention:** Implement "Output Sanitization" as a final step in data processing pipelines. Ensure sanitization logic is reusable and safe (e.g., does not unintentionally destroy formatting like trailing whitespace unless intended).
+
+## 2026-02-04 - Unbounded Audio File Loading
+**Vulnerability:** `AudioFeedback` loaded entire audio files into memory without size checks, allowing DoS via large files.
+**Learning:** Library methods like `wave.readframes` (or similar bulk loaders) can be dangerous if input size is unchecked, especially when configuration is user-controlled.
+**Prevention:** Always enforce strict size limits on file inputs before reading them into memory.

--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -25,6 +25,9 @@ except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
 
 
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
+
+
 class AudioFeedback:
     def __init__(
         self,
@@ -130,6 +133,13 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        # Security: Prevent DoS by rejecting large files
+        size = path.stat().st_size
+        if size > MAX_AUDIO_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"Audio file too large: {path} ({size} bytes > {MAX_AUDIO_FILE_SIZE_BYTES} bytes)"
+            )
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -50,27 +50,31 @@ class TestAudioFeedback(unittest.TestCase):
         """_load_and_cache should read WAV and cache data."""
         af = AudioFeedback(logger=self.mock_logger, enabled=True)
 
-        # Setup wave mock
-        mock_wf = MagicMock()
-        mock_wave.open.return_value.__enter__.return_value = mock_wf
-        mock_wf.getframerate.return_value = 44100
-        mock_wf.getnchannels.return_value = 1
-        mock_wf.getnframes.return_value = 1000
-        mock_wf.readframes.return_value = b"\x00" * 2000
+        # Mock Path.stat to avoid FileNotFoundError and pass size check
+        with patch("pathlib.Path.stat") as mock_stat:
+            mock_stat.return_value.st_size = 1000  # Safe size
 
-        mock_audio_data = MagicMock()
-        mock_np.frombuffer.return_value = mock_audio_data
+            # Setup wave mock
+            mock_wf = MagicMock()
+            mock_wave.open.return_value.__enter__.return_value = mock_wf
+            mock_wf.getframerate.return_value = 44100
+            mock_wf.getnchannels.return_value = 1
+            mock_wf.getnframes.return_value = 1000
+            mock_wf.readframes.return_value = b"\x00" * 2000
 
-        key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+            mock_audio_data = MagicMock()
+            mock_np.frombuffer.return_value = mock_audio_data
 
-        mock_wave.open.assert_called_with("/fake/sound.wav", "rb")
-        mock_np.frombuffer.assert_called()
+            key = "test_key"
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
-        # Check returned data and cache
-        expected = (mock_audio_data, 44100)
-        self.assertEqual(data, expected)
-        self.assertEqual(af._cache[key], expected)
+            mock_wave.open.assert_called_with("/fake/sound.wav", "rb")
+            mock_np.frombuffer.assert_called()
+
+            # Check returned data and cache
+            expected = (mock_audio_data, 44100)
+            self.assertEqual(data, expected)
+            self.assertEqual(af._cache[key], expected)
 
     @patch("chirp.audio_feedback.sd")
     @patch("chirp.audio_feedback.winsound", None)
@@ -94,31 +98,35 @@ class TestAudioFeedback(unittest.TestCase):
         mock_np.float32 = np.float32
         mock_np.frombuffer = MagicMock()
 
-        # Mock wave reading
-        mock_wf = MagicMock()
-        mock_wave.open.return_value.__enter__.return_value = mock_wf
-        mock_wf.getframerate.return_value = 44100
-        mock_wf.getnchannels.return_value = 1
-        mock_wf.readframes.return_value = b"\x00" * 2000  # Dummy bytes
-        mock_wf.getnframes.return_value = 1000
+        # Mock Path.stat
+        with patch("pathlib.Path.stat") as mock_stat:
+            mock_stat.return_value.st_size = 1000
 
-        # Inject real numpy logic for frombuffer so we get an array back
-        # We need frombuffer to return something we control to verify scaling
-        original_audio = np.array([1000, -1000, 2000], dtype=np.int16)
-        mock_np.frombuffer.return_value = original_audio
+            # Mock wave reading
+            mock_wf = MagicMock()
+            mock_wave.open.return_value.__enter__.return_value = mock_wf
+            mock_wf.getframerate.return_value = 44100
+            mock_wf.getnchannels.return_value = 1
+            mock_wf.readframes.return_value = b"\x00" * 2000  # Dummy bytes
+            mock_wf.getnframes.return_value = 1000
 
-        af = AudioFeedback(logger=self.mock_logger, enabled=True, volume=0.5)
+            # Inject real numpy logic for frombuffer so we get an array back
+            # We need frombuffer to return something we control to verify scaling
+            original_audio = np.array([1000, -1000, 2000], dtype=np.int16)
+            mock_np.frombuffer.return_value = original_audio
 
-        key = "test_key"
-        data = af._load_and_cache(Path("/fake/sound.wav"), key)
+            af = AudioFeedback(logger=self.mock_logger, enabled=True, volume=0.5)
 
-        audio_data, samplerate = data
+            key = "test_key"
+            data = af._load_and_cache(Path("/fake/sound.wav"), key)
 
-        # Check scaling was applied (values should be halved)
-        self.assertEqual(samplerate, 44100)
-        self.assertEqual(audio_data[0], 500)
-        self.assertEqual(audio_data[1], -500)
-        self.assertEqual(audio_data[2], 1000)
+            audio_data, samplerate = data
+
+            # Check scaling was applied (values should be halved)
+            self.assertEqual(samplerate, 44100)
+            self.assertEqual(audio_data[0], 500)
+            self.assertEqual(audio_data[1], -500)
+            self.assertEqual(audio_data[2], 1000)
 
     @patch("chirp.audio_feedback.sd")
     @patch("chirp.audio_feedback.winsound", None)

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import logging
+
+from chirp.audio_feedback import AudioFeedback
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger("test_logger")
+
+    @patch("chirp.audio_feedback.sd", new=MagicMock())
+    @patch("chirp.audio_feedback.winsound", None)
+    @patch("chirp.audio_feedback.wave")
+    @patch("chirp.audio_feedback.np")
+    def test_audio_file_size_limit(self, mock_np, mock_wave):
+        """Verify that files larger than 5MB are rejected."""
+        # Ensure AudioFeedback thinks sounddevice is available so it tries to load/read the file
+        mock_np.frombuffer = MagicMock()
+
+        af = AudioFeedback(logger=self.logger, enabled=True)
+
+        # Mock file path and stat
+        mock_path = MagicMock(spec=Path)
+        mock_path.stat.return_value.st_size = 6 * 1024 * 1024  # 6MB
+        mock_path.__str__.return_value = "/fake/large_file.wav"
+
+        # We expect this to fail AFTER we implement the fix.
+        # For now, without the fix, it would proceed to open the file via wave.open.
+        # So if we run this NOW, it should fail the assertion (it won't raise ValueError).
+        # Or it might fail because wave.open mock isn't fully set up for reading.
+        # But my goal is to verify the fix later.
+
+        # Setup mock_wave so it doesn't crash if called
+        mock_wf = MagicMock()
+        mock_wave.open.return_value.__enter__.return_value = mock_wf
+        mock_wf.getframerate.return_value = 44100
+        mock_wf.getnchannels.return_value = 1
+        mock_wf.readframes.return_value = b""
+        mock_wf.getnframes.return_value = 0
+
+        with self.assertRaises(ValueError) as cm:
+            af._load_and_cache(mock_path, "test_key")
+
+        self.assertIn("Audio file too large", str(cm.exception))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
🚨 Severity: MEDIUM
💡 Vulnerability: AudioFeedback loaded audio files into memory without checking size, allowing potential Denial of Service (DoS) if a large file was configured.
🎯 Impact: Memory exhaustion leading to application crash.
🔧 Fix: Enforced a 5MB limit on audio files in `AudioFeedback._load_and_cache`.
✅ Verification: Added `tests/test_audio_security.py` and updated `tests/test_audio_feedback.py` to verify the size check works.

---
*PR created automatically by Jules for task [4310325430207320295](https://jules.google.com/task/4310325430207320295) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added 5MB size limit to prevent DoS via large audio files

- Implemented file size validation in `_load_and_cache` method

- Updated existing tests to mock file size checks

- Added comprehensive security test suite for audio file handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AudioFeedback._load_and_cache"] --> B["Check file size"]
  B --> C{Size > 5MB?}
  C -->|Yes| D["Raise ValueError"]
  C -->|No| E["Load audio file"]
  F["MAX_AUDIO_FILE_SIZE_BYTES constant"] --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add file size limit to audio loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implemented file size validation in <code>_load_and_cache</code> method before <br>loading<br> <li> Raises <code>ValueError</code> if audio file exceeds size limit<br> <li> Prevents memory exhaustion from large audio files</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/61/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Update tests to mock file size checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Updated <code>test_load_and_cache_sounddevice</code> to mock <code>Path.stat</code> for size <br>check<br> <li> Updated <code>test_load_and_cache_with_volume_scaling</code> to mock file size <br>validation<br> <li> Added proper mocking to pass the new size limit check<br> <li> Wrapped test logic with <code>patch</code> context manager for file stat mocking</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/61/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+45/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>Add audio security test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>Created new security test file for audio file handling<br> <li> Added <code>test_audio_file_size_limit</code> to verify 6MB files are rejected<br> <li> Tests that <code>ValueError</code> is raised with appropriate error message<br> <li> Validates the 5MB size limit enforcement</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/61/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentinel.md</strong><dd><code>Document audio file DoS vulnerability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/sentinel.md

<ul><li>Documented the unbounded audio file loading vulnerability<br> <li> Recorded learning about dangers of unchecked bulk file loaders<br> <li> Added prevention strategy for file input size limits</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/61/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

