### PR TITLE
🛡️ Sentinel: Fix potential DoS via large audio file loading

### DIFF
--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -130,6 +130,18 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        # Security: Enforce 5MB limit to prevent memory exhaustion
+        MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024
+        try:
+            if path.stat().st_size > MAX_AUDIO_FILE_SIZE_BYTES:
+                self._logger.warning(
+                    "Audio file %s too large (max 5MB), skipping.", path
+                )
+                return None
+        except OSError:
+            # File might not exist or be inaccessible; let downstream handle it
+            pass
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,42 @@
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Mock dependencies before importing audio_feedback if necessary,
+# but usually patching inside the test is cleaner if the module imports them in try/except.
+# However, chirp.audio_feedback imports them at top level.
+# We'll use patch.dict on sys.modules if needed, or patch where they are used.
+
+from chirp.audio_feedback import AudioFeedback
+
+class TestAudioSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+
+    @patch("chirp.audio_feedback.sd", new=MagicMock())
+    @patch("chirp.audio_feedback.np", new=MagicMock())
+    @patch("chirp.audio_feedback.winsound", None)
+    def test_load_large_file_returns_none(self):
+        """Verify that files larger than 5MB are rejected."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+        large_size = 5 * 1024 * 1024 + 1
+        fake_path = Path("fake_large.wav")
+
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value.st_size = large_size
+
+            # Depending on implementation, it might try to open file if check is missing.
+            # Since the file doesn't exist, wave.open would raise FileNotFoundError.
+            # We want to verify it DOES NOT try to open the file.
+
+            with patch("chirp.audio_feedback.wave.open") as mock_wave_open:
+                result = af._load_and_cache(fake_path, "key")
+
+                self.assertIsNone(result, "Should return None for oversized files")
+                self.mock_logger.warning.assert_called()
+                # Verify wave.open was NOT called
+                mock_wave_open.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
Sentinel 🛡️ identified a potential Denial of Service (DoS) vulnerability where loading a large audio file (user-provided or malicious) could exhaust system memory.

This PR adds a 5MB file size limit to `AudioFeedback._load_and_cache`. Files exceeding this limit are logged and skipped, returning `None` instead of crashing the application.

A new test file `tests/test_audio_security.py` has been added to verify this behavior using mocked file stats. All existing tests pass.

---
*PR created automatically by Jules for task [14606561704196115571](https://jules.google.com/task/14606561704196115571) started by @Whamp*


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce 5MB file size limit in `AudioFeedback._load_and_cache` to prevent DoS attacks

- Prevents memory exhaustion from loading large audio files

- Returns `None` for oversized files with warning log

- Added security test suite to verify file size validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Loading"] --> B{"File Size Check"}
  B -->|"≤ 5MB"| C["Load and Cache"]
  B -->|"> 5MB"| D["Log Warning"]
  D --> E["Return None"]
  C --> F["Play Sound"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add file size limit validation for audio loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added 5MB file size validation in <code>_load_and_cache</code> method<br> <li> Checks <code>path.stat().st_size</code> before loading audio file<br> <li> Logs warning and returns <code>None</code> for oversized files<br> <li> Handles <code>OSError</code> gracefully for inaccessible files</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/62/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>Add audio file size security tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>New test file for audio security validation<br> <li> Tests that files larger than 5MB are rejected<br> <li> Verifies <code>wave.open</code> is not called for oversized files<br> <li> Mocks file system and dependencies for isolated testing</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/62/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

