### PR TITLE
🎨 Palette: Add persistent CLI status indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Persistent CLI Status with Rich
+**Learning:** `rich.console.Status` context managers can wrap blocking calls like `keyboard.wait()` to provide a persistent "Ready" state, and updates from worker threads are thread-safe if the same `Status` object is used.
+**Action:** Use `with console.status("Ready"): blocking_call()` for CLI apps that need a persistent status line, and update it via `status.update()` from event handlers.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -61,8 +61,11 @@ class ChirpApp:
         if not console:
             console = Console(stderr=True)
 
+        self.console = console
+        self.status_indicator = self.console.status("Ready", spinner="dots")
+
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -94,7 +97,8 @@ class ChirpApp:
         try:
             self._register_hotkey()
             self.logger.info("Chirp ready. Toggle recording with %s", self.config.primary_shortcut)
-            self.keyboard.wait()
+            with self.status_indicator:
+                self.keyboard.wait()
         except KeyboardInterrupt:
             self.logger.info("Interrupted, exiting.")
 
@@ -122,6 +126,7 @@ class ChirpApp:
             self.audio_feedback.play_error(self.config.error_sound_path)
             return
         self._recording = True
+        self.status_indicator.update("Recording...", spinner="point")
         self.audio_feedback.play_start(self.config.start_sound_path)
         self.logger.info("Recording started")
 
@@ -143,28 +148,33 @@ class ChirpApp:
         self.logger.debug("Stopping audio capture")
         waveform = self.audio_capture.stop()
         self._recording = False
+        self.status_indicator.update("Transcribing...", spinner="dots")
         self.audio_feedback.play_stop(self.config.stop_sound_path)
         self.logger.info("Recording stopped (%s samples)", waveform.size)
         self._executor.submit(self._transcribe_and_inject, waveform)
 
     def _transcribe_and_inject(self, waveform) -> None:
-        start_time = time.perf_counter()
-        if waveform.size == 0:
-            self.logger.warning("No audio samples captured")
-            return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
-        except Exception as exc:
-            self.logger.exception("Transcription failed: %s", exc)
-            self.audio_feedback.play_error(self.config.error_sound_path)
-            return
-        duration = time.perf_counter() - start_time
-        self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
-        if not text.strip():
-            self.logger.info("Transcription empty; skipping paste")
-            return
-        self.logger.debug("Transcription: %s", text)
-        self.text_injector.inject(text)
+            start_time = time.perf_counter()
+            if waveform.size == 0:
+                self.logger.warning("No audio samples captured")
+                return
+            try:
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            except Exception as exc:
+                self.logger.exception("Transcription failed: %s", exc)
+                self.audio_feedback.play_error(self.config.error_sound_path)
+                return
+            duration = time.perf_counter() - start_time
+            self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
+            if not text.strip():
+                self.logger.info("Transcription empty; skipping paste")
+                return
+            self.logger.debug("Transcription: %s", text)
+            self.text_injector.inject(text)
+        finally:
+            if not self._recording:
+                self.status_indicator.update("Ready", spinner="dots")
 
     def _log_capture_status(self, message: str) -> None:
         self.logger.debug("Audio status: %s", message)

--- a/tests/test_ui_status.py
+++ b/tests/test_ui_status.py
@@ -1,0 +1,97 @@
+import sys
+from unittest.mock import MagicMock, call
+
+# Mock low-level dependencies before imports to avoid environment issues
+sys.modules["sounddevice"] = MagicMock()
+sys.modules["winsound"] = MagicMock()
+sys.modules["keyboard"] = MagicMock()
+
+import unittest
+from unittest.mock import patch, ANY
+
+# Import after mocking
+from chirp.main import ChirpApp
+
+class TestUIStatus(unittest.TestCase):
+    @patch("chirp.main.get_logger")
+    @patch("chirp.main.ConfigManager")
+    @patch("chirp.main.ParakeetManager")
+    @patch("chirp.main.AudioCapture")
+    @patch("chirp.main.AudioFeedback")
+    @patch("chirp.main.KeyboardShortcutManager")
+    @patch("chirp.main.TextInjector")
+    @patch("chirp.main.Console") # Mock the Console class used in main.py
+    def test_status_lifecycle(self, MockConsole, MockInjector, MockKeyboard, MockFeedback, MockCapture, MockParakeet, MockConfig, MockGetLogger):
+        """Verify that the UI status indicator transitions correctly through states."""
+
+        # Setup mocks
+        mock_console_instance = MockConsole.return_value
+        mock_status = MagicMock()
+        mock_console_instance.status.return_value = mock_status
+
+        # Mock Config
+        mock_config = MockConfig.return_value.load.return_value
+        mock_config.max_recording_duration = 0
+        mock_config.audio_feedback = False
+
+        # Ensure logger has no RichHandler
+        mock_logger = MockGetLogger.return_value
+        mock_logger.handlers = []
+
+        # Initialize App
+        app = ChirpApp()
+
+        # Prevent ThreadPoolExecutor from actually running the task in background during test to avoid race
+        # We can just verify _executor.submit was called, and manually call _transcribe_and_inject
+        app._executor = MagicMock()
+
+        # 1. Verify initialization
+        self.assertTrue(hasattr(app, "status_indicator"))
+        mock_console_instance.status.assert_any_call("Ready", spinner="dots")
+
+        # 2. Test Start Recording
+        app._start_recording()
+        mock_status.update.assert_called_with("Recording...", spinner="point")
+
+        # 3. Test Stop Recording
+        app.audio_capture.stop.return_value = MagicMock(size=100)
+        app._stop_recording()
+        # Should set to Transcribing
+        mock_status.update.assert_called_with("Transcribing...", spinner="dots")
+
+        # Verify task submitted
+        app._executor.submit.assert_called_with(app._transcribe_and_inject, ANY)
+
+        # 4. Test Transcribe Finished
+        # Manually call the worker method
+        app._transcribe_and_inject(MagicMock(size=100))
+        mock_status.update.assert_called_with("Ready", spinner="dots")
+
+    @patch("chirp.main.get_logger")
+    @patch("chirp.main.ConfigManager")
+    @patch("chirp.main.ParakeetManager")
+    @patch("chirp.main.AudioCapture")
+    @patch("chirp.main.AudioFeedback")
+    @patch("chirp.main.KeyboardShortcutManager")
+    @patch("chirp.main.TextInjector")
+    @patch("chirp.main.Console")
+    def test_run_wraps_keyboard_wait(self, MockConsole, MockInjector, MockKeyboard, MockFeedback, MockCapture, MockParakeet, MockConfig, MockGetLogger):
+        """Verify that app.run() wraps keyboard.wait() in the status context."""
+        mock_console_instance = MockConsole.return_value
+        mock_status = MagicMock()
+        mock_console_instance.status.return_value = mock_status
+
+        # Mock Config
+        mock_config = MockConfig.return_value.load.return_value
+        mock_config.max_recording_duration = 0
+
+        app = ChirpApp()
+
+        app.run()
+
+        mock_status.__enter__.assert_called()
+        app.keyboard.wait.assert_called()
+        mock_status.__exit__.assert_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
Adds a persistent visual status indicator to the CLI using `rich`. The app now displays "Ready", "Recording...", or "Transcribing..." with spinners to provide better feedback on its internal state. Includes comprehensive unit tests.

---
*PR created automatically by Jules for task [11651727359360095606](https://jules.google.com/task/11651727359360095606) started by @Whamp*


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add persistent CLI status indicator using `rich.console.Status`

- Display "Ready", "Recording...", "Transcribing..." states with spinners

- Wrap `keyboard.wait()` in status context for continuous feedback

- Add comprehensive unit tests for status lifecycle transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Init["Initialize Status<br/>Ready"] --> Run["Run with<br/>Status Context"]
  Run --> Record["Start Recording<br/>Recording..."]
  Record --> Stop["Stop Recording<br/>Transcribing..."]
  Stop --> Transcribe["Transcribe Audio"]
  Transcribe --> Ready["Reset to Ready"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Integrate persistent status indicator throughout app lifecycle</code></dd></summary>
<hr>

src/chirp/main.py

<ul><li>Store <code>console</code> instance and create persistent <code>status_indicator</code> in <br><code>__init__</code><br> <li> Wrap <code>keyboard.wait()</code> in status context manager for continuous display<br> <li> Update status to "Recording..." when audio capture starts<br> <li> Update status to "Transcribing..." when recording stops<br> <li> Reset status to "Ready" after transcription completes or fails<br> <li> Refactor <code>_transcribe_and_inject()</code> with try-finally block for status <br>reset</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/63/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+28/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ui_status.py</strong><dd><code>Add unit tests for UI status indicator lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_ui_status.py

<ul><li>Create new test file with comprehensive unit tests for status <br>indicator<br> <li> Mock all low-level dependencies (sounddevice, keyboard, winsound) <br>before imports<br> <li> Test status lifecycle: initialization, recording, transcribing, and <br>ready states<br> <li> Verify status context manager wraps <code>keyboard.wait()</code> correctly<br> <li> Validate status updates are called with correct messages and spinners</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/63/files#diff-c127e8fbac40a9a34d6eea703f638535848f2dbdb36a06a59f634eacfeb31b7e">+97/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Document persistent status implementation learnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Document learning about <code>rich.console.Status</code> context managers<br> <li> Record best practice for wrapping blocking calls with persistent <br>status<br> <li> Note thread-safety of status updates from worker threads</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/63/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

