### PR TITLE
🎨 Palette: Add persistent CLI status indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2024-05-22 - Visual Feedback Discrepancy
+**Learning:** The memory/documentation claimed a persistent visual status indicator existed, but the code revealed only log messages were used. Visual feedback (spinners) provides immediate mode assurance that logs (historical) cannot.
+**Action:** Always verify "known" features in code before assuming they exist. When implementing CLI tools, prioritize persistent state indicators over scrolling logs for the primary interaction loop.

--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -61,8 +61,11 @@ class ChirpApp:
         if not console:
             console = Console(stderr=True)
 
+        self.console = console
+        self.status_indicator = self.console.status("Ready", spinner="dots")
+
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -94,8 +97,10 @@ class ChirpApp:
         try:
             self._register_hotkey()
             self.logger.info("Chirp ready. Toggle recording with %s", self.config.primary_shortcut)
+            self.status_indicator.start()
             self.keyboard.wait()
         except KeyboardInterrupt:
+            self.status_indicator.stop()
             self.logger.info("Interrupted, exiting.")
 
     def _register_hotkey(self) -> None:
@@ -123,6 +128,7 @@ class ChirpApp:
             return
         self._recording = True
         self.audio_feedback.play_start(self.config.start_sound_path)
+        self.status_indicator.update("[bold red]Recording...[/bold red]", spinner="point")
         self.logger.info("Recording started")
 
         if self.config.max_recording_duration > 0:
@@ -144,27 +150,32 @@ class ChirpApp:
         waveform = self.audio_capture.stop()
         self._recording = False
         self.audio_feedback.play_stop(self.config.stop_sound_path)
+        self.status_indicator.update("[bold green]Transcribing...[/bold green]", spinner="dots")
         self.logger.info("Recording stopped (%s samples)", waveform.size)
         self._executor.submit(self._transcribe_and_inject, waveform)
 
     def _transcribe_and_inject(self, waveform) -> None:
-        start_time = time.perf_counter()
-        if waveform.size == 0:
-            self.logger.warning("No audio samples captured")
-            return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
-        except Exception as exc:
-            self.logger.exception("Transcription failed: %s", exc)
-            self.audio_feedback.play_error(self.config.error_sound_path)
-            return
-        duration = time.perf_counter() - start_time
-        self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
-        if not text.strip():
-            self.logger.info("Transcription empty; skipping paste")
-            return
-        self.logger.debug("Transcription: %s", text)
-        self.text_injector.inject(text)
+            start_time = time.perf_counter()
+            if waveform.size == 0:
+                self.logger.warning("No audio samples captured")
+                return
+            try:
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            except Exception as exc:
+                self.logger.exception("Transcription failed: %s", exc)
+                self.audio_feedback.play_error(self.config.error_sound_path)
+                return
+            duration = time.perf_counter() - start_time
+            self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
+            if not text.strip():
+                self.logger.info("Transcription empty; skipping paste")
+                return
+            self.logger.debug("Transcription: %s", text)
+            self.text_injector.inject(text)
+        finally:
+            if not self._recording:
+                self.status_indicator.update("Ready", spinner="dots")
 
     def _log_capture_status(self, message: str) -> None:
         self.logger.debug("Audio status: %s", message)

--- a/tests/test_ui_ux.py
+++ b/tests/test_ui_ux.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import types
+import numpy as np
+import time
+
+# Mock dependencies not available in the test environment
+if "sounddevice" not in sys.modules:
+    mock_sd = types.ModuleType("sounddevice")
+    mock_sd.InputStream = MagicMock()
+    sys.modules["sounddevice"] = mock_sd
+
+if sys.platform == "win32" and "winsound" not in sys.modules:
+    mock_winsound = types.ModuleType("winsound")
+    sys.modules["winsound"] = mock_winsound
+
+# Import after mocking
+from chirp.main import ChirpApp
+
+class TestUIUX(unittest.TestCase):
+    @patch("chirp.main.ParakeetManager")
+    @patch("chirp.main.AudioCapture")
+    @patch("chirp.main.AudioFeedback")
+    @patch("chirp.main.KeyboardShortcutManager")
+    @patch("chirp.main.ConfigManager")
+    def test_status_indicator_updates(self, mock_config, mock_keyboard, mock_feedback, mock_capture, mock_parakeet):
+        """Verify that the status indicator updates during the recording lifecycle."""
+        # Setup mocks
+        mock_config_instance = mock_config.return_value
+        mock_config_instance.load.return_value.audio_feedback = False
+        mock_config_instance.load.return_value.max_recording_duration = 0
+        mock_config_instance.load.return_value.clipboard_clear_delay = 1.0
+        mock_config_instance.load.return_value.word_overrides = {}
+        mock_config_instance.load.return_value.paste_mode = "ctrl"
+        mock_config_instance.load.return_value.post_processing = ""
+        mock_config_instance.load.return_value.clipboard_behavior = False
+        mock_config_instance.model_dir.return_value = "dummy"
+
+        # Mock Parakeet transcribe return
+        mock_parakeet.return_value.transcribe.return_value = "test transcription"
+
+        # Initialize App
+        app = ChirpApp()
+
+        # Mock executor to prevent automatic background execution
+        app._executor = MagicMock()
+
+        # Mock the status indicator
+        app.status_indicator = MagicMock()
+
+        # 1. Start Recording
+        app._start_recording()
+
+        # Verify status update to "Recording..."
+        app.status_indicator.update.assert_called_with("[bold red]Recording...[/bold red]", spinner="point")
+
+        # 2. Stop Recording
+        # Prepare dummy waveform
+        mock_capture.return_value.stop.return_value = np.zeros(16000)
+
+        app._stop_recording()
+
+        # Verify status update to "Transcribing..."
+        app.status_indicator.update.assert_called_with("[bold green]Transcribing...[/bold green]", spinner="dots")
+
+        # Verify that the task was submitted
+        app._executor.submit.assert_called()
+
+        # 3. Transcribe completion
+        # Call _transcribe_and_inject directly to verify the reset logic.
+
+        waveform = np.zeros(16000)
+        app._transcribe_and_inject(waveform)
+
+        # Verify status reset to "Ready"
+        app.status_indicator.update.assert_called_with("Ready", spinner="dots")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
💡 What: Added a persistent status indicator to the CLI using `rich` library.
🎯 Why: To provide immediate visual feedback (Ready, Recording, Transcribing) to the user, improving the UX over scrolling logs.
📸 Before/After: Before was just logs. After has a spinner at the bottom showing current state.
♿ Accessibility: Provides clear state indication.

---
*PR created automatically by Jules for task [15023239142878418116](https://jules.google.com/task/15023239142878418116) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add persistent CLI status indicator using `rich.console.Status`

- Update status during recording and transcribing lifecycle events

- Display "Ready", "Recording...", and "Transcribing..." states

- Add comprehensive tests for status indicator updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp Init"] -- "Create status_indicator" --> B["Status: Ready"]
  C["Start Recording"] -- "update status" --> D["Status: Recording"]
  D -- "Stop Recording" --> E["Status: Transcribing"]
  E -- "Transcription Complete" --> B
  F["Keyboard Interrupt"] -- "stop indicator" --> G["Exit"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Implement persistent status indicator lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Store <code>console</code> instance and initialize <code>status_indicator</code> in <code>__init__</code><br> <li> Start status indicator in <code>run()</code> method and stop on keyboard interrupt<br> <li> Update status to "Recording..." when audio capture begins<br> <li> Update status to "Transcribing..." when recording stops<br> <li> Reset status to "Ready" after transcription completes in finally block<br> <li> Refactor <code>_transcribe_and_inject</code> with try-finally for proper cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/65/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+28/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ui_ux.py</strong><dd><code>Add UI/UX tests for status indicator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_ui_ux.py

<ul><li>Create new test file for UI/UX functionality<br> <li> Mock all external dependencies (sounddevice, winsound, <br>ParakeetManager, etc.)<br> <li> Test status indicator updates during recording start, stop, and <br>transcription<br> <li> Verify status transitions from "Recording..." to "Transcribing..." to <br>"Ready"<br> <li> Mock executor to prevent background task execution during tests</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/65/files#diff-8305964918ab941cbdc10d45ac18eb0c2082acb308ce08f6391f1aabd5121e98">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>palette.md</strong><dd><code>Record learning from status indicator implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.jules/palette.md

<ul><li>Document learning about visual feedback vs log messages discrepancy<br> <li> Record insight that persistent state indicators are superior to <br>scrolling logs<br> <li> Capture action item to verify features in code before assuming <br>existence</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/65/files#diff-89226fe981cd633570ed7dd1bbdbe5a51c325eeab68f37487cc62b0588c62f25">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

