### PR TITLE
🛡️ Sentinel: Enforce file size limit on audio feedback assets

### DIFF
--- a/src/chirp/audio_feedback.py
+++ b/src/chirp/audio_feedback.py
@@ -25,6 +25,9 @@ except ImportError:  # pragma: no cover - non-Windows development
     winsound = None  # type: ignore[assignment]
 
 
+MAX_AUDIO_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB
+
+
 class AudioFeedback:
     def __init__(
         self,
@@ -130,6 +133,20 @@ class AudioFeedback:
             self._logger.exception("Failed to play sound %s: %s", asset_name, exc)
 
     def _load_and_cache(self, path: Path, key: str) -> Any:
+        try:
+            file_size = path.stat().st_size
+            if file_size > MAX_AUDIO_FILE_SIZE_BYTES:
+                self._logger.warning(
+                    "Audio file %s is too large (%d bytes). Max allowed: %d bytes.",
+                    path,
+                    file_size,
+                    MAX_AUDIO_FILE_SIZE_BYTES,
+                )
+                return None
+        except OSError as exc:
+            self._logger.warning("Could not stat audio file %s: %s", path, exc)
+            return None
+
         if self._use_sounddevice:
             # Load as numpy array for volume-controlled playback via sounddevice
             with wave.open(str(path), "rb") as wf:

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -43,12 +43,16 @@ class TestAudioFeedback(unittest.TestCase):
             af._load_and_cache.assert_called_once()
             af._play_cached.assert_called_once_with("data")
 
+    @patch("pathlib.Path.stat")
     @patch("chirp.audio_feedback.sd")
     @patch("chirp.audio_feedback.np")
     @patch("chirp.audio_feedback.wave")
-    def test_load_and_cache_sounddevice(self, mock_wave, mock_np, mock_sd):
+    def test_load_and_cache_sounddevice(self, mock_wave, mock_np, mock_sd, mock_stat):
         """_load_and_cache should read WAV and cache data."""
         af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock valid file size
+        mock_stat.return_value.st_size = 1024
 
         # Setup wave mock
         mock_wf = MagicMock()
@@ -81,13 +85,17 @@ class TestAudioFeedback(unittest.TestCase):
         af._play_cached(mock_data)
         mock_sd.play.assert_called_with(mock_data[0], 44100)
 
+    @patch("pathlib.Path.stat")
     @patch("chirp.audio_feedback.sd")
     @patch("chirp.audio_feedback.np")
     @patch("chirp.audio_feedback.wave")
     @patch("chirp.audio_feedback.winsound", None)
-    def test_load_and_cache_with_volume_scaling(self, mock_wave, mock_np, mock_sd):
+    def test_load_and_cache_with_volume_scaling(self, mock_wave, mock_np, mock_sd, mock_stat):
         """_load_and_cache should scale audio when volume < 1.0."""
         import numpy as np
+
+        # Mock valid file size
+        mock_stat.return_value.st_size = 1024
 
         # Create real numpy array for testing
         mock_np.int16 = np.int16

--- a/tests/test_audio_security.py
+++ b/tests/test_audio_security.py
@@ -1,0 +1,52 @@
+import logging
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Need to patch sys.modules before importing chirp.audio_feedback to mock imports if needed,
+# but since the module handles ImportError, we can just patch the imported names.
+
+from chirp.audio_feedback import AudioFeedback
+
+class TestAudioFeedbackSecurity(unittest.TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+
+    @patch("chirp.audio_feedback.np")
+    @patch("chirp.audio_feedback.sd", new=MagicMock())
+    @patch("chirp.audio_feedback.winsound", None)
+    @patch("pathlib.Path.stat")
+    def test_load_large_file_fails(self, mock_stat, mock_np):
+        """_load_and_cache should return None if file is too large (>5MB)."""
+        af = AudioFeedback(logger=self.mock_logger, enabled=True)
+
+        # Mock file size to be slightly larger than 5MB (5 * 1024 * 1024 + 1)
+        mock_stat.return_value.st_size = 5 * 1024 * 1024 + 1
+
+        # We need to mock wave.open so it doesn't actually try to open a file
+        # if the check fails (or if it doesn't fail yet)
+        with patch("chirp.audio_feedback.wave") as mock_wave:
+            # Setup mock to behave "normally" if called
+            mock_wf = MagicMock()
+            mock_wave.open.return_value.__enter__.return_value = mock_wf
+            mock_wf.getframerate.return_value = 44100
+            mock_wf.getnchannels.return_value = 1
+            mock_wf.readframes.return_value = b"\x00" * 100
+            mock_wf.getnframes.return_value = 50
+
+            # Mock numpy behavior to avoid errors if the code proceeds
+            mock_np.frombuffer.return_value = MagicMock()
+
+            result = af._load_and_cache(Path("/fake/large_file.wav"), "key")
+
+            # This assertion should fail until the fix is implemented
+            self.assertIsNone(result, "Should return None for files larger than 5MB")
+
+            # Verify a warning was logged
+            self.mock_logger.warning.assert_called()
+            # Check if the warning message contains expected text
+            args, _ = self.mock_logger.warning.call_args
+            self.assertIn("too large", args[0])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
Implemented a security enhancement to limit the size of audio feedback files to 5MB. This prevents a potential Denial of Service (DoS) vulnerability where loading a maliciously large audio file could cause memory exhaustion and crash the application.

Changes:
- Modified `src/chirp/audio_feedback.py` to include `MAX_AUDIO_FILE_SIZE_BYTES` and a file size check.
- Created `tests/test_audio_security.py` to verify the new security constraint.
- Updated `tests/test_audio_feedback.py` to properly mock file system statistics in existing tests.

---
*PR created automatically by Jules for task [8979471785784312993](https://jules.google.com/task/8979471785784312993) started by @Whamp*


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Enforce 5MB file size limit on audio feedback assets

- Prevents DoS vulnerability from memory exhaustion attacks

- Added file size validation in `_load_and_cache` method

- Created comprehensive security test suite

- Updated existing tests to mock file system operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Audio File Loading"] --> B["Check File Size"]
  B --> C{Size <= 5MB?}
  C -->|Yes| D["Load and Cache"]
  C -->|No| E["Return None + Log Warning"]
  D --> F["Play Audio"]
  E --> G["Skip Playback"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio_feedback.py</strong><dd><code>Add 5MB file size limit validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chirp/audio_feedback.py

<ul><li>Added <code>MAX_AUDIO_FILE_SIZE_BYTES</code> constant set to 5MB<br> <li> Implemented file size validation in <code>_load_and_cache</code> method<br> <li> Returns <code>None</code> and logs warning if file exceeds size limit<br> <li> Handles <code>OSError</code> exceptions during file stat operations</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/67/files#diff-c53c5ef34c63bd590754a2f885759bf37bdd60522efec96b9fdf9a9e6a622de4">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_audio_feedback.py</strong><dd><code>Mock file system operations in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_feedback.py

<ul><li>Added <code>@patch("pathlib.Path.stat")</code> decorator to two test methods<br> <li> Mocked <code>path.stat().st_size</code> to return valid file size (1024 bytes)<br> <li> Updated <code>test_load_and_cache_sounddevice</code> and <br><code>test_load_and_cache_with_volume_scaling</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/67/files#diff-58bd0ec0f6c76873087f227d5e6ded8c665f55e1f4471206cbb5201184b23285">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_audio_security.py</strong><dd><code>Add audio file size security tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_audio_security.py

<ul><li>Created new security test file with <code>TestAudioFeedbackSecurity</code> class<br> <li> Implemented <code>test_load_large_file_fails</code> to verify 5MB limit enforcement<br> <li> Validates that oversized files return <code>None</code> and trigger warning logs<br> <li> Mocks all external dependencies including wave, numpy, and sounddevice</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/67/files#diff-4d4b0c21787cb72cf3ac8cd434384662893578cf269520773b8894345d72c4e0">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

