### PR TITLE
Add persistent UI status indicators

### DIFF
--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -6,7 +6,7 @@ import logging
 import platform
 import threading
 import time
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import numpy as np
 
@@ -60,9 +60,11 @@ class ChirpApp:
                 break
         if not console:
             console = Console(stderr=True)
+        self.console = console
+        self.status_indicator: Optional[Any] = None
 
         try:
-            with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
+            with self.console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
                 self.parakeet = ParakeetManager(
                     model_name=self.config.parakeet_model,
                     quantization=self.config.parakeet_quantization,
@@ -94,7 +96,9 @@ class ChirpApp:
         try:
             self._register_hotkey()
             self.logger.info("Chirp ready. Toggle recording with %s", self.config.primary_shortcut)
-            self.keyboard.wait()
+            with self.console.status("Ready", spinner="dots") as status:
+                self.status_indicator = status
+                self.keyboard.wait()
         except KeyboardInterrupt:
             self.logger.info("Interrupted, exiting.")
 
@@ -116,10 +120,14 @@ class ChirpApp:
     def _start_recording(self) -> None:
         self.logger.debug("Starting audio capture")
         try:
+            if self.status_indicator:
+                self.status_indicator.update("[bold red]Recording...[/bold red]", spinner="point")
             self.audio_capture.start()
         except Exception as exc:
             self.logger.error("Audio capture start failed: %s", exc)
             self.audio_feedback.play_error(self.config.error_sound_path)
+            if self.status_indicator:
+                self.status_indicator.update("Ready", spinner="dots")
             return
         self._recording = True
         self.audio_feedback.play_start(self.config.start_sound_path)
@@ -141,6 +149,9 @@ class ChirpApp:
             self._stop_timer = None
 
         self.logger.debug("Stopping audio capture")
+        if self.status_indicator:
+            self.status_indicator.update("[bold green]Transcribing...[/bold green]", spinner="dots")
+
         waveform = self.audio_capture.stop()
         self._recording = False
         self.audio_feedback.play_stop(self.config.stop_sound_path)
@@ -148,23 +159,27 @@ class ChirpApp:
         self._executor.submit(self._transcribe_and_inject, waveform)
 
     def _transcribe_and_inject(self, waveform) -> None:
-        start_time = time.perf_counter()
-        if waveform.size == 0:
-            self.logger.warning("No audio samples captured")
-            return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
-        except Exception as exc:
-            self.logger.exception("Transcription failed: %s", exc)
-            self.audio_feedback.play_error(self.config.error_sound_path)
-            return
-        duration = time.perf_counter() - start_time
-        self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
-        if not text.strip():
-            self.logger.info("Transcription empty; skipping paste")
-            return
-        self.logger.debug("Transcription: %s", text)
-        self.text_injector.inject(text)
+            start_time = time.perf_counter()
+            if waveform.size == 0:
+                self.logger.warning("No audio samples captured")
+                return
+            try:
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            except Exception as exc:
+                self.logger.exception("Transcription failed: %s", exc)
+                self.audio_feedback.play_error(self.config.error_sound_path)
+                return
+            duration = time.perf_counter() - start_time
+            self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
+            if not text.strip():
+                self.logger.info("Transcription empty; skipping paste")
+                return
+            self.logger.debug("Transcription: %s", text)
+            self.text_injector.inject(text)
+        finally:
+            if self.status_indicator and not self._recording:
+                self.status_indicator.update("Ready", spinner="dots")
 
     def _log_capture_status(self, message: str) -> None:
         self.logger.debug("Audio status: %s", message)

--- a/tests/test_ui_status.py
+++ b/tests/test_ui_status.py
@@ -1,0 +1,156 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+class TestChirpAppUI(unittest.TestCase):
+    def setUp(self):
+        # Patch sys.modules to mock hard dependencies
+        self.modules_patcher = patch.dict(sys.modules, {
+            "sounddevice": MagicMock(),
+            "keyboard": MagicMock(),
+            "pyperclip": MagicMock(),
+            # We don't mock parakeet_manager module here, we rely on @patch in tests or it's safe to import
+        })
+        self.modules_patcher.start()
+
+        # We need to import ChirpApp here, after mocking sys.modules
+        # We use strict import to ensure we get the version using our mocks
+        # If it was already imported by another test, we might need to reload it?
+        # But for safety, we assume it wasn't, or we force reload if needed.
+        # However, verifying 'reload' with mocks is tricky.
+
+        # For now, just import. If it fails due to previous import, it means we have shared state.
+        import chirp.main
+        import importlib
+        importlib.reload(chirp.main) # Force usage of mocked sounddevice/keyboard
+
+        self.ChirpApp = chirp.main.ChirpApp
+
+        # Setup mocks for class instance
+        self.mock_logger = MagicMock()
+
+        # We can't use @patch decorators easily on setUp if we want to patch imports inside chirp.main
+        # because chirp.main is imported dynamically.
+        # But we can patch 'chirp.main.ParakeetManager' using patch() context managers or start/stop.
+
+        self.patches = []
+
+        # Patch dependencies of ChirpApp
+        p_pm = patch("chirp.main.ParakeetManager")
+        self.mock_parakeet_cls = p_pm.start()
+        self.patches.append(p_pm)
+
+        p_ac = patch("chirp.main.AudioCapture")
+        self.mock_capture_cls = p_ac.start()
+        self.patches.append(p_ac)
+
+        p_af = patch("chirp.main.AudioFeedback")
+        self.mock_feedback_cls = p_af.start()
+        self.patches.append(p_af)
+
+        p_ti = patch("chirp.main.TextInjector")
+        self.mock_injector_cls = p_ti.start()
+        self.patches.append(p_ti)
+
+        p_gl = patch("chirp.main.get_logger")
+        self.mock_get_logger = p_gl.start()
+        self.mock_get_logger.return_value = self.mock_logger
+        self.patches.append(p_gl)
+
+        p_exec = patch("chirp.main.concurrent.futures.ThreadPoolExecutor")
+        self.mock_executor_cls = p_exec.start()
+        self.patches.append(p_exec)
+
+        p_timer = patch("chirp.main.threading.Timer")
+        self.mock_timer = p_timer.start()
+        self.patches.append(p_timer)
+
+        # Prevent RichHandler from being used so we control console
+        self.mock_logger.handlers = []
+
+        # Initialize app
+        self.app = self.ChirpApp()
+
+        # Inject mock console and status
+        self.mock_console = MagicMock()
+        self.mock_status = MagicMock()
+        self.app.console = self.mock_console
+
+        # Manually set status indicator for testing methods in isolation
+        self.app.status_indicator = self.mock_status
+
+        # Ensure executor is a mock
+        self.app._executor = self.mock_executor_cls.return_value
+
+    def tearDown(self):
+        for p in reversed(self.patches):
+            p.stop()
+        self.modules_patcher.stop()
+
+        # Clean up sys.modules to prevent pollution
+        to_remove = [k for k in sys.modules if k.startswith("chirp.main") or k.startswith("chirp.audio_capture")]
+        for k in to_remove:
+            del sys.modules[k]
+
+    def test_start_recording_updates_status(self):
+        """Test that starting recording updates the status spinner."""
+        self.app._start_recording()
+
+        # Verify status update
+        self.mock_status.update.assert_called_with("[bold red]Recording...[/bold red]", spinner="point")
+
+        # Verify logger called
+        self.mock_logger.info.assert_any_call("Recording started")
+
+    def test_stop_recording_updates_status(self):
+        """Test that stopping recording updates the status spinner."""
+        # Setup: pretend we are recording
+        self.app._recording = True
+
+        # Mock waveform
+        mock_waveform = MagicMock()
+        mock_waveform.size = 100
+        self.app.audio_capture.stop.return_value = mock_waveform
+
+        self.app._stop_recording()
+
+        # Verify status update "Transcribing..." was called at some point
+        self.mock_status.update.assert_any_call("[bold green]Transcribing...[/bold green]", spinner="dots")
+
+    def test_transcribe_and_inject_updates_status(self):
+        """Test that transcription updates status back to ready."""
+        # Setup
+        mock_waveform = MagicMock()
+        mock_waveform.size = 100
+
+        # Mock successful transcription
+        self.app.parakeet.transcribe.return_value = "Test text"
+
+        self.app._transcribe_and_inject(mock_waveform)
+
+        # Verify status update back to ready
+        self.mock_status.update.assert_any_call("Ready", spinner="dots")
+
+    def test_transcribe_does_not_reset_status_if_recording(self):
+        """Test that transcription does NOT reset status if recording started again."""
+        # Setup
+        mock_waveform = MagicMock()
+        mock_waveform.size = 100
+
+        # Mock successful transcription
+        self.app.parakeet.transcribe.return_value = "Test text"
+
+        # Simulate recording started during transcription
+        self.app._recording = True
+
+        self.app._transcribe_and_inject(mock_waveform)
+
+        # Verify status calls
+        calls = self.mock_status.update.call_args_list
+        # Check that no call was made with "Ready"
+        for call in calls:
+            args, _ = call
+            self.assertNotEqual(args[0], "Ready", "Should not set status to Ready if recording")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
Added a persistent `rich.console.Status` spinner to the main application loop to provide visual feedback.
- Displays "Ready" (dots) when idle.
- Displays "Recording..." (point, red) when capturing audio.
- Displays "Transcribing..." (dots, green) when processing.
- Includes unit tests in `tests/test_ui_status.py` verifying state transitions and race condition handling.

---
*PR created automatically by Jules for task [17587739269275448204](https://jules.google.com/task/17587739269275448204) started by @Whamp*


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add persistent status spinner showing app state (Ready/Recording/Transcribing)

- Update status indicator during recording start, stop, and transcription

- Reset status to Ready after transcription completes, unless recording resumed

- Include comprehensive unit tests for UI state transitions and race conditions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App Running"] -->|"with status spinner"| B["Ready State"]
  B -->|"toggle_recording"| C["Recording State"]
  C -->|"update status"| D["Recording... spinner"]
  D -->|"stop_recording"| E["Transcribing State"]
  E -->|"update status"| F["Transcribing... spinner"]
  F -->|"transcribe_and_inject"| G["Ready State"]
  G -->|"unless _recording=True"| H["Stay in Recording"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add persistent status indicators throughout app lifecycle</code></dd></summary>
<hr>

src/chirp/main.py

<ul><li>Store <code>console</code> instance as <code>self.console</code> and add <code>self.status_indicator</code> <br>attribute<br> <li> Wrap main event loop with persistent status spinner showing "Ready" <br>state<br> <li> Update status to "[bold red]Recording...[/bold red]" with point <br>spinner when recording starts<br> <li> Update status to "[bold green]Transcribing...[/bold green]" when <br>recording stops<br> <li> Reset status to "Ready" after transcription completes, with guard to <br>prevent reset if recording resumed<br> <li> Add error handling to reset status on audio capture failures<br> <li> Refactor <code>_transcribe_and_inject</code> with try-finally block for status <br>cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/69/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+34/-19</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ui_status.py</strong><dd><code>Add unit tests for UI status indicator state transitions</code>&nbsp; </dd></summary>
<hr>

tests/test_ui_status.py

<ul><li>Create comprehensive test suite for UI status indicator functionality<br> <li> Mock system dependencies (sounddevice, keyboard, pyperclip) and <br>ChirpApp components<br> <li> Test status update on recording start with "[bold <br>red]Recording...[/bold red]" and point spinner<br> <li> Test status update on recording stop with "[bold <br>green]Transcribing...[/bold green]"<br> <li> Test status reset to "Ready" after successful transcription<br> <li> Test race condition handling where recording resumes during <br>transcription (status not reset)</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/69/files#diff-c127e8fbac40a9a34d6eea703f638535848f2dbdb36a06a59f634eacfeb31b7e">+156/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

