### PR TITLE
🎨 Palette: Add persistent CLI status indicator

### DIFF
--- a/src/chirp/main.py
+++ b/src/chirp/main.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.status import Status
 
 from .audio_capture import AudioCapture
 from .audio_feedback import AudioFeedback
@@ -60,6 +61,8 @@ class ChirpApp:
                 break
         if not console:
             console = Console(stderr=True)
+        self.console = console
+        self.status_indicator: Optional[Status] = self.console.status("Ready", spinner="dots")
 
         try:
             with console.status("[bold green]Initializing Parakeet model...[/bold green]", spinner="dots"):
@@ -94,7 +97,11 @@ class ChirpApp:
         try:
             self._register_hotkey()
             self.logger.info("Chirp ready. Toggle recording with %s", self.config.primary_shortcut)
-            self.keyboard.wait()
+            if self.status_indicator:
+                with self.status_indicator:
+                    self.keyboard.wait()
+            else:
+                self.keyboard.wait()
         except KeyboardInterrupt:
             self.logger.info("Interrupted, exiting.")
 
@@ -122,6 +129,8 @@ class ChirpApp:
             self.audio_feedback.play_error(self.config.error_sound_path)
             return
         self._recording = True
+        if self.status_indicator:
+            self.status_indicator.update("Recording...", spinner="point", spinner_style="red")
         self.audio_feedback.play_start(self.config.start_sound_path)
         self.logger.info("Recording started")
 
@@ -143,28 +152,34 @@ class ChirpApp:
         self.logger.debug("Stopping audio capture")
         waveform = self.audio_capture.stop()
         self._recording = False
+        if self.status_indicator:
+            self.status_indicator.update("Transcribing...", spinner="dots", spinner_style="green")
         self.audio_feedback.play_stop(self.config.stop_sound_path)
         self.logger.info("Recording stopped (%s samples)", waveform.size)
         self._executor.submit(self._transcribe_and_inject, waveform)
 
     def _transcribe_and_inject(self, waveform) -> None:
-        start_time = time.perf_counter()
-        if waveform.size == 0:
-            self.logger.warning("No audio samples captured")
-            return
         try:
-            text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
-        except Exception as exc:
-            self.logger.exception("Transcription failed: %s", exc)
-            self.audio_feedback.play_error(self.config.error_sound_path)
-            return
-        duration = time.perf_counter() - start_time
-        self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
-        if not text.strip():
-            self.logger.info("Transcription empty; skipping paste")
-            return
-        self.logger.debug("Transcription: %s", text)
-        self.text_injector.inject(text)
+            start_time = time.perf_counter()
+            if waveform.size == 0:
+                self.logger.warning("No audio samples captured")
+                return
+            try:
+                text = self.parakeet.transcribe(waveform, sample_rate=16_000, language=self.config.language)
+            except Exception as exc:
+                self.logger.exception("Transcription failed: %s", exc)
+                self.audio_feedback.play_error(self.config.error_sound_path)
+                return
+            duration = time.perf_counter() - start_time
+            self.logger.debug("Transcription finished in %.2fs (chars=%s)", duration, len(text))
+            if not text.strip():
+                self.logger.info("Transcription empty; skipping paste")
+                return
+            self.logger.debug("Transcription: %s", text)
+            self.text_injector.inject(text)
+        finally:
+            if not self._recording and self.status_indicator:
+                self.status_indicator.update("Ready", spinner="dots", spinner_style="white")
 
     def _log_capture_status(self, message: str) -> None:
         self.logger.debug("Audio status: %s", message)

--- a/tests/test_ui_status.py
+++ b/tests/test_ui_status.py
@@ -1,0 +1,128 @@
+import unittest
+from unittest.mock import MagicMock, patch, ANY
+import sys
+import numpy as np
+
+# Mock dependencies before importing ChirpApp
+sys.modules["sounddevice"] = MagicMock()
+sys.modules["keyboard"] = MagicMock()
+
+# Since we modify sys.modules, we need to ensure chirp.main is reloaded or imported after mocks
+# But here we are writing a script that will be executed fresh.
+from chirp.main import ChirpApp
+
+class TestUIStatus(unittest.TestCase):
+    def setUp(self):
+        # Patch dependencies
+        self.patchers = []
+
+        self.mock_logger = MagicMock()
+        # Mock handlers to be empty list so loop works
+        self.mock_logger.handlers = []
+        patch_logger = patch("chirp.main.get_logger", return_value=self.mock_logger)
+        self.patchers.append(patch_logger)
+        patch_logger.start()
+
+        # Mock ParakeetManager to avoid model loading
+        self.mock_parakeet_cls = patch("chirp.main.ParakeetManager")
+        self.mock_parakeet = self.mock_parakeet_cls.start()
+        self.patchers.append(self.mock_parakeet_cls)
+
+        # Mock AudioCapture
+        self.mock_audio_capture_cls = patch("chirp.main.AudioCapture")
+        self.mock_audio_capture = self.mock_audio_capture_cls.start()
+        self.patchers.append(self.mock_audio_capture_cls)
+
+        # Mock AudioFeedback
+        self.mock_audio_feedback_cls = patch("chirp.main.AudioFeedback")
+        self.mock_audio_feedback = self.mock_audio_feedback_cls.start()
+        self.patchers.append(self.mock_audio_feedback_cls)
+
+        # Mock TextInjector
+        self.mock_text_injector_cls = patch("chirp.main.TextInjector")
+        self.mock_text_injector = self.mock_text_injector_cls.start()
+        self.patchers.append(self.mock_text_injector_cls)
+
+        # Mock KeyboardShortcutManager
+        self.mock_keyboard_cls = patch("chirp.main.KeyboardShortcutManager")
+        self.mock_keyboard = self.mock_keyboard_cls.start()
+        self.patchers.append(self.mock_keyboard_cls)
+
+        # Mock Console and Status
+        self.mock_console_cls = patch("chirp.main.Console")
+        self.mock_console = self.mock_console_cls.start()
+        self.patchers.append(self.mock_console_cls)
+
+        # Setup mock status
+        self.mock_status = MagicMock()
+        # console.status(...) returns this mock status
+        self.mock_console.return_value.status.return_value = self.mock_status
+
+    def tearDown(self):
+        for patcher in self.patchers:
+            patcher.stop()
+
+    def test_initialization_sets_ready_status(self):
+        app = ChirpApp()
+        # Verify status created with "Ready"
+        app.console.status.assert_any_call("Ready", spinner="dots")
+        self.assertEqual(app.status_indicator, self.mock_status)
+
+    def test_run_activates_status(self):
+        app = ChirpApp()
+        app.run()
+        # Verify status context manager used
+        self.mock_status.__enter__.assert_called()
+        # Verify keyboard wait called
+        app.keyboard.wait.assert_called()
+        self.mock_status.__exit__.assert_called()
+
+    def test_start_recording_updates_status(self):
+        app = ChirpApp()
+        app.config.max_recording_duration = 0  # Disable timer
+        app._start_recording()
+
+        # Check update call
+        self.mock_status.update.assert_called_with("Recording...", spinner="point", spinner_style="red")
+
+    def test_stop_recording_updates_status(self):
+        app = ChirpApp()
+        # Simulate recording state
+        app._recording = True
+
+        # Mock executor submit to not run thread
+        app._executor = MagicMock()
+
+        app._stop_recording()
+
+        # Check update call
+        self.mock_status.update.assert_called_with("Transcribing...", spinner="dots", spinner_style="green")
+
+    def test_transcription_resets_status_when_not_recording(self):
+        app = ChirpApp()
+        # Ensure not recording
+        app._recording = False
+
+        waveform = np.zeros(10)
+        app._transcribe_and_inject(waveform)
+
+        # Check reset to Ready
+        self.mock_status.update.assert_called_with("Ready", spinner="dots", spinner_style="white")
+
+    def test_transcription_does_not_reset_status_when_recording(self):
+        app = ChirpApp()
+        # Simulate recording started again during transcription
+        app._recording = True
+
+        waveform = np.zeros(10)
+        app._transcribe_and_inject(waveform)
+
+        # Check that update("Ready", ...) was NOT called
+        ready_calls = [
+            call for call in self.mock_status.update.mock_calls
+            if len(call.args) > 0 and call.args[0] == "Ready"
+        ]
+        self.assertEqual(len(ready_calls), 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
This PR adds a persistent status indicator to the Chirp CLI application to provide immediate visual feedback to the user about the application's state.

**Why:**
Previously, the user had to rely on log messages to know if the application was recording or transcribing. A visual indicator makes the experience more intuitive and responsive.

**What:**
-   Modified `ChirpApp` in `src/chirp/main.py` to initialize and manage a `rich.status.Status` object.
-   Updated `run`, `_start_recording`, `_stop_recording`, and `_transcribe_and_inject` to update the status text and spinner style.
-   Added `tests/test_ui_status.py` to verify the logic.

**Accessibility:**
-   Uses clear text labels ("Ready", "Recording...", "Transcribing...") alongside spinners.
-   Uses distinct colors (Red for recording, Green for processing) to aid quick recognition.

---
*PR created automatically by Jules for task [13951464115053580190](https://jules.google.com/task/13951464115053580190) started by @Whamp*


___

### **PR Type**
Enhancement


___

### **Description**
- Add persistent status indicator to CLI showing application state

- Display "Ready", "Recording...", and "Transcribing..." with distinct visual styles

- Update status during recording, transcription, and completion phases

- Add comprehensive test suite for status indicator state transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChirpApp Init"] -->|"Create Status"| B["Status: Ready"]
  B -->|"User presses hotkey"| C["Status: Recording"]
  C -->|"User releases hotkey"| D["Status: Transcribing"]
  D -->|"Transcription complete"| B
  D -->|"Error occurs"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Implement persistent status indicator with state updates</code>&nbsp; </dd></summary>
<hr>

src/chirp/main.py

<ul><li>Import <code>Status</code> from <code>rich.status</code> for UI status indicator<br> <li> Store <code>console</code> instance and initialize <code>status_indicator</code> in <code>__init__</code><br> <li> Wrap <code>keyboard.wait()</code> in status context manager in <code>run()</code> method<br> <li> Update status to "Recording..." with red spinner in <code>_start_recording()</code><br> <li> Update status to "Transcribing..." with green spinner in <br><code>_stop_recording()</code><br> <li> Wrap transcription logic in try-finally block to reset status to <br>"Ready" after completion</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/70/files#diff-357eee76878accec259f7b9dff78890c599c7f67e4e2567d353e5ce4628b2da8">+32/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ui_status.py</strong><dd><code>Add comprehensive tests for UI status indicator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_ui_status.py

<ul><li>Create new test file with comprehensive test coverage for status <br>indicator<br> <li> Mock all external dependencies (ParakeetManager, AudioCapture, <br>Console, etc.)<br> <li> Test status initialization with "Ready" state<br> <li> Test status context manager activation during <code>run()</code><br> <li> Test status updates during recording and transcription phases<br> <li> Test status reset to "Ready" after transcription completion<br> <li> Test status preservation when recording restarts during transcription</ul>


</details>


  </td>
  <td><a href="https://github.com/Whamp/chirp-stt/pull/70/files#diff-c127e8fbac40a9a34d6eea703f638535848f2dbdb36a06a59f634eacfeb31b7e">+128/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

